### PR TITLE
Fix Matrices/3dalloc2.c - leak free once more.

### DIFF
--- a/Matrices/3dalloc2.c
+++ b/Matrices/3dalloc2.c
@@ -6,6 +6,17 @@
 
 static int fail_after = 0;
 static int num_allocs = 0;
+static int debug = 0;
+
+static void xfree(void *vp)
+{
+    if (debug)
+    {
+        static int free_counter = 0;
+        printf("free :%.2d: %p\n", ++free_counter, vp);
+    }
+    free(vp);
+}
 
 static void *xmalloc(size_t size)
 {
@@ -14,7 +25,13 @@ static void *xmalloc(size_t size)
         fputs("Out of memory\n", stdout);
         return 0;
     }
-    return malloc(size);
+    void *vp = malloc(size);
+    if (debug)
+    {
+        static int alloc_counter = 0;
+        printf("alloc:%.2d: %p (%zu)\n", ++alloc_counter, vp, size);
+    }
+    return vp;
 }
 
 static int ***allocate_3d_array(int no1, int ****a)
@@ -28,8 +45,8 @@ static int ***allocate_3d_array(int no1, int ****a)
         if (((*a)[l]=(int**)xmalloc((no1+1)*sizeof(int*))) == 0)
         {
             for (int l1 = 0; l1 < l; l1++)
-                free((*a)[l1]);
-            free(*a);
+                xfree((*a)[l1]);
+            xfree(*a);
             *a = 0;
             return 0;
         }
@@ -43,16 +60,17 @@ static int ***allocate_3d_array(int no1, int ****a)
             {
                 /* Release prior items in current row */
                 for (int h1 = 0; h1 < h; h1++)
-                    free((*a)[l][h1]);
-                free((*a)[l]);
+                    xfree((*a)[l][h1]);
                 /* Release items in prior rows */
                 for (int l1 = 0; l1 < l; l1++)
                 {
                     for (int h1 = 0; h1 < no1; h1++)
-                        free((*a)[l1][h1]);
-                    free((*a)[l1]);
+                        xfree((*a)[l1][h1]);
                 }
-                free(*a);
+                /* Release all the rows */
+                for (int l0 = 0; l0 < no1; l0++)
+                    xfree((*a)[l0]);
+                xfree(*a);
                 *a = 0;
                 return 0;
             }
@@ -74,10 +92,10 @@ static void destroy_3d_array(int no1, int ***a)
         for (int l = 0; l < no1; l++)
         {
             for (int h = 0; h < no1; h++)
-                free(a[l][h]);
-            free(a[l]);
+                xfree(a[l][h]);
+            xfree(a[l]);
         }
-        free(a);
+        xfree(a);
     }
 }
 
@@ -106,20 +124,51 @@ static void test_allocation(int no1)
     destroy_3d_array(no1, a);
 }
 
-int main(void)
+static const char helpstr[] =
+    "  -d       Turn debug printing on\n"
+    "  -h       Print this help message and exit\n"
+    "  -n loop  Minimum number of failures (default 0)\n"
+    "  -s size  Size of array to allocate (default 5)\n"
+    "  -x loop  Maximum number of failures (default 33)\n"
+    ;
+
+int main(int argc, char **argv)
 {
     int no1 = 5;
+    int min = 0;
+    int max = 33;
+    int opt;
 
-    for (fail_after = 0; fail_after < 33; fail_after++)
+    while ((opt = getopt(argc, argv, "dhn:s:x:")) != -1)
     {
-        printf("Fail after: %d\n", fail_after);
+        switch (opt)
+        {
+        case 'd':
+            debug = 1;
+            break;
+        case 'h':
+            puts(helpstr);
+            return EXIT_SUCCESS;
+        case 'n':
+            min = atoi(optarg);
+            break;
+        case 's':
+            no1 = atoi(optarg);
+            break;
+        case 'x':
+            max = atoi(optarg);
+            break;
+        default:
+            return EXIT_FAILURE;
+        }
+    }
+
+    for (fail_after = min; fail_after < max; fail_after++)
+    {
+        printf("Fail after: %d (size %d)\n", fail_after, no1);
         num_allocs = 0;
         test_allocation(no1);
     }
-
-    printf("PID %d - waiting for some data to exit:", (int)getpid());
-    fflush(0);
-    getchar();
 
     return 0;
 }


### PR DESCRIPTION
Add command line option handling, including help.
Add debug (-d) to print allocations and frees.
Add and use xfree() to log frees.
Add logging to xmalloc().
Fix recovery code in allocate_3d_array() for innermost allocations.
Add min (-n default 0) size for fail_after.
Add max (-x default 33) size for fail_after.
Add size (-s default 5) for array dimension.
Remove "waiting for some data to exit" code.
