### PR TITLE
Reinstate the flawed memory release code to 3dalloc2.c

### DIFF
--- a/Matrices/3dalloc2.c
+++ b/Matrices/3dalloc2.c
@@ -1,11 +1,12 @@
 /* SO 18579583 Segmentation fault error in 3d array memory allocation */
 /*
-** It appears that 3dalloc2.c was known-to-be-buggy in the releasing of
+** The code in 3dalloc2.c was known-to-be-buggy in the releasing of
 ** memory on allocation failure, and 3dalloc3.c contained the fix for
 ** the problem.  Careful testing of 3dalloc2.c showed the bug, and
 ** fixing produced essentially the same fix a second time.  Mildly
-** exasperating that there was no annotation about this.  So, after some
-** work, the files 3dalloc2.c and 3dalloc3.c are the same.
+** exasperating that there was no annotation about this.  Add the
+** improved testing framework but leave the memory release bugs in situ.
+** Code now annotated to reduce chance of re-redoing the debugging.
 */
 #include <assert.h>
 #include <stdio.h>
@@ -69,15 +70,15 @@ static int ***allocate_3d_array(int no1, int ****a)
                 /* Release prior items in current (partial) row */
                 for (int h1 = 0; h1 < h; h1++)
                     xfree((*a)[l][h1]);
+                xfree((*a)[l]);    /* Flawed! */
                 /* Release items in prior (complete) rows */
                 for (int l1 = 0; l1 < l; l1++)
                 {
                     for (int h1 = 0; h1 < no1; h1++)
                         xfree((*a)[l1][h1]);
+                    xfree((*a)[l1]);       /* Flawed! */
                 }
-                /* Release entries in first (complete) level of array */
-                for (int l0 = 0; l0 < no1; l0++)
-                    xfree((*a)[l0]);
+                /* Flawed - loop missing! */
                 xfree(*a);
                 *a = 0;
                 return 0;


### PR DESCRIPTION
Looking at the answer, it was clearly known that 3dalloc2.c was
flawed in the way it releases memory on an error.  After fixing
the bug, it is best to reinstate the error and let 3dalloc3.c be
the fixed code - as in the answer to SO 1857-9583.
