### PR TITLE
Use BASEDIR in top-level makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,8 +3,7 @@
 
 include etc/soq-head.mk
 
-IFLAGS  = -I./inc
-LDFLAG1 = -L./lib
+BASEDIR = .
 
 default:
 	@echo "You must specify a target to build"


### PR DESCRIPTION
Control location of headers and libraries with BASEDIR (one line) instead of tinkering with IFLAGS and LDFLAG1
