### PR TITLE
Add README.md to AES and SHA-256 directories.

### DIFF
--- a/AES/README.md
+++ b/AES/README.md
@@ -1,0 +1,15 @@
+### AES
+
+This code is simply a copy of a reference implementation of AES,
+produced by Christophe Devine and released under GNU GPL v2 or later.
+(Source from http://www.cs.rochester.edu/u/brown/Crypto/src/AES.c)
+
+It probably does not have a long-term future here.
+
+NB: Critiques include:
+
+* Too many global variables (they should be file static).
+* The code can only handle a complete single-block message.
+* No support for any encryption mode other than ECB and that by default
+  rather than design.
+

--- a/SHA-256/README.md
+++ b/SHA-256/README.md
@@ -1,0 +1,10 @@
+### SHA-1 and RFC 4634
+
+This code is directly copied from https://tools.ietf.org/html/rfc4634 or
+https://tools.ietf.org/rfc/rfc4634.txts - no originality of any sort is
+claimed for it.
+
+It supports 160, 224, 256, 384, 512 bit hashes, and HMAC too.
+
+The code is probably reliable; it is unlikely to be the fastest possible.
+

--- a/SHA-256/sha.h
+++ b/SHA-256/sha.h
@@ -27,7 +27,6 @@
 #include <stdint.h>
 /*
  * If you do not have the ISO standard stdint.h header file, then you
-
  * must typedef the following:
  *    name              meaning
  *  uint64_t         unsigned 64 bit integer


### PR DESCRIPTION
Show provenance of code in README.md files, though
the information is in the source files too.
Fix glitch in sha.h where blank line was introduced in the middle
of a comment, caused by page boundaries.
