### PR TITLE
Primes: use timecmd to report run times to milliseconds

### DIFF
--- a/Matrices/README.md
+++ b/Matrices/README.md
@@ -6,8 +6,8 @@ src/so-abcd-wxyz directories that should be here too.
 
 ### SO 1719-2011
 
-* `matmul89.c` - variable-dimension 2D array multiplication in strict C89.
-* `matmul99.c` - variable-dimension 2D array multiplication in C99 using VLA.
+* `matmul89.c` &mdash; variable-dimension 2D array multiplication in strict C89.
+* `matmul99.c` &mdash; variable-dimension 2D array multiplication in C99 using VLA.
 
 ### SO 1857-9583
 
@@ -15,23 +15,23 @@ There are multiple answers for the question.
 The crux seems to be about handling recovery from memory allocation
 failure.
 
-* `3dalloc1.c` - Minimal fix, leaking memory, but not crashing.
-* `3dalloc2.c` - Better fix, releasing most memory if allocation fails
+* `3dalloc1.c` &mdash; Minimal fix, leaking memory, but not crashing.
+* `3dalloc2.c` &mdash; Better fix, releasing most memory if allocation fails
     part way through.  Definitely has a leak though.
-* `3dalloc3.c` - Reworked variant of `3dalloc3.c` with proper (simpler) memory allocation.
-* `3dalloc4.c` - Dramatically reduced memory allocations, dramatically simplifying recovery.
-* `matmake3d.c` - Another crack at this issue.
+* `3dalloc3.c` &mdash; Reworked variant of `3dalloc3.c` with proper (simpler) memory allocation.
+* `3dalloc4.c` &mdash; Dramatically reduced memory allocations, dramatically simplifying recovery.
+* `matmake3d.c` &mdash; Another crack at this issue.
     Not sure about its relation to the `3dalloc?.c` code.
 
 ### SO 2635-0717
 
-* `2da.c` - memory allocation for a 2D array of arrays with negative indices.
+* `2da.c` &mdash; memory allocation for a 2D array of arrays with negative indices.
 
 ### SO 3256-5694
 
-* `vlastruct.c`: another variable-dimension 2D array multiplication in C99 using VLA. 
+* `vlastruct.c` &mdash; another variable-dimension 2D array multiplication in C99 using VLA. 
 
 ### SO 3259-8224
 
-* `vlamat.c`: - and another variable-dimension 2D array multiplication in C99 using VLA.
+* `vlamat.c` &mdash; and another variable-dimension 2D array multiplication in C99 using VLA.
 

--- a/Primes/run
+++ b/Primes/run
@@ -1,6 +1,4 @@
 #!/bin/bash
 
 blanklines
-date
-echo
-"$@"
+timecmd -m -- "$@"

--- a/Primes/test-5
+++ b/Primes/test-5
@@ -5,6 +5,6 @@ count=${1:-1000}
 if rmk -q eratosthenes-5 ||
    rmk    eratosthenes-5
 then
-    eratosthenes-5 $count
-    test-0 $count
+    timecmd -m -- eratosthenes-5 $count
+    timecmd -m -- test-0 $count
 fi

--- a/Primes/test-6
+++ b/Primes/test-6
@@ -6,7 +6,7 @@ if rmk -q eratosthenes-6 eratosthenes-5 ||
    rmk    eratosthenes-6 eratosthenes-5
 then
     #valgrind --suppressions=../suppressions eratosthenes-6 $count
-    eratosthenes-6 ${E6_DEBUG} $count
-    eratosthenes-5 $count
-    test-0 $count
+    timecmd -m -- eratosthenes-6 ${E6_DEBUG} $count
+    timecmd -m -- eratosthenes-5 $count
+    timecmd -m -- test-0 $count
 fi


### PR DESCRIPTION
The run script uses timecmd -m.
test-5 and test-6 run multiple commands,
so each of those is run under timecmd -m too.
