### PR TITLE
Sphinx/readme.001

### DIFF
--- a/src/add-readme.sh
+++ b/src/add-readme.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Find official description of SO questions for README.md file
+
+site="http://stackoverflow.com"
+for dir in so-*
+do
+    [ -h "$dir" ] && continue;
+    [ -f "$dir/README.md" ] && continue;
+    echo $dir
+    (
+    qd=${dir#so-}
+    qn=${qd/-/}
+    redirect=$(curl -s "$site/q/$qn" |
+               perl -lne 'print $1 if m/.*Object moved to <a href="([^"]*)".*/')
+    title=$(curl -s "$redirect" |
+            perl -lne 'print $1 if m/<title>(?:[^-]*? - )?(.+?) - [^-]*<\/title>.*/')
+    echo "### Stack Overflow Question $qd"
+    echo
+    echo "[SO $qd](http://stackoverflow.com/q/$qn) &mdash;"
+    echo "$title"
+    ) > $dir/README.md
+done

--- a/src/so-0036-7309/README.md
+++ b/src/so-0036-7309/README.md
@@ -1,4 +1,4 @@
 ### Stack Overflow Question 0036-7309
 
-[SO 0036-7309](http://stackoverflow.com/q/00367309) &mdash;
-Page Not Found
+[SO 0036-7309](http://stackoverflow.com/q/00367309) &mdash; (deleted)
+Which command line commands style do you prefer?

--- a/src/so-0036-7309/README.md
+++ b/src/so-0036-7309/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0036-7309
+
+[SO 0036-7309](http://stackoverflow.com/q/00367309) &mdash;
+Page Not Found

--- a/src/so-0040-2377/README.md
+++ b/src/so-0040-2377/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0040-2377
+
+[SO 0040-2377](http://stackoverflow.com/q/00402377) &mdash;
+Using getopts in bash shell script to get long and short command line options

--- a/src/so-0044-0061/README.md
+++ b/src/so-0044-0061/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0044-0061
+
+[SO 0044-0061](http://stackoverflow.com/q/00440061) &mdash;
+Convert 12-hour date/time to 24-hour date/time

--- a/src/so-0141-0563/README.md
+++ b/src/so-0141-0563/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0141-0563
+
+[SO 0141-0563](http://stackoverflow.com/q/01410563) &mdash;
+What is the difference between a definition and a declaration?

--- a/src/so-0143-3204/README.md
+++ b/src/so-0143-3204/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0143-3204
+
+[SO 0143-3204](http://stackoverflow.com/q/01433204) &mdash;
+How do I use extern to share variables between source files in C?

--- a/src/so-0242-2712/README.md
+++ b/src/so-0242-2712/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0242-2712
+
+[SO 0242-2712](http://stackoverflow.com/q/02422712) &mdash;
+C - Rounding integer division (instead of truncating)

--- a/src/so-0355-5689/README.md
+++ b/src/so-0355-5689/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0355-5689
+
+[SO 0355-5689](http://stackoverflow.com/q/03555689) &mdash;
+Selecting and analysing window of points in an array

--- a/src/so-0429-4928/README.md
+++ b/src/so-0429-4928/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0429-4928
+
+[SO 0429-4928](http://stackoverflow.com/q/04294928) &mdash;
+UDP in c: Extra characters getting added to file when saving received data in chunks

--- a/src/so-0436-1132/README.md
+++ b/src/so-0436-1132/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0436-1132
+
+[SO 0436-1132](http://stackoverflow.com/q/04361132) &mdash;
+Problems freeing 2d array after realloc

--- a/src/so-0512-5919/README.md
+++ b/src/so-0512-5919/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0512-5919
+
+[SO 0512-5919](http://stackoverflow.com/q/05125919) &mdash;
+stat() error &#39;No such file or directory&#39; when file name is returned by readdir()

--- a/src/so-0612-7503/README.md
+++ b/src/so-0612-7503/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0612-7503
+
+[SO 0612-7503](http://stackoverflow.com/q/06127503) &mdash;
+Shuffle array in C

--- a/src/so-0629-7596/README.md
+++ b/src/so-0629-7596/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0629-7596
+
+[SO 0629-7596](http://stackoverflow.com/q/06297596) &mdash;
+Ordering SQL results based on predecessor

--- a/src/so-0686-8618/README.md
+++ b/src/so-0686-8618/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0686-8618
+
+[SO 0686-8618](http://stackoverflow.com/q/06868618) &mdash;
+Is it possible to write a function that can dump arbitrary dimensional int array in C?

--- a/src/so-0765-1397/README.md
+++ b/src/so-0765-1397/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0765-1397
+
+[SO 0765-1397](http://stackoverflow.com/q/07651397) &mdash;
+Calc cell convertor in C

--- a/src/so-0765-6915/README.md
+++ b/src/so-0765-6915/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0765-6915
+
+[SO 0765-6915](http://stackoverflow.com/q/07656915) &mdash;
+reading from a pipe in c

--- a/src/so-0858-2632/README.md
+++ b/src/so-0858-2632/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0858-2632
+
+[SO 0858-2632](http://stackoverflow.com/q/08582632) &mdash;
+working with named pipes and semaphores in linux

--- a/src/so-0885-4855/README.md
+++ b/src/so-0885-4855/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0885-4855
+
+[SO 0885-4855](http://stackoverflow.com/q/08854855) &mdash;
+Which row (in order by some column) in a table corresponds to a row in another table?

--- a/src/so-0918-7614/README.md
+++ b/src/so-0918-7614/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 0918-7614
+
+[SO 0918-7614](http://stackoverflow.com/q/09187614) &mdash;
+How do I have a comma inside braces inside a macro argument when parentheses cause a syntax error?

--- a/src/so-1102-7679/README.md
+++ b/src/so-1102-7679/README.md
@@ -1,8 +1,8 @@
 ### Redirecting standard output and standard error
 
-See:
-
-* http://stackoverflow.com/q/962255
-* http://stackoverflow.com/q/11027679
+* [SO 0096-2255](http://stackoverflow.com/q/962255) &mdash;
+How to store standard error in a variable in a Bash script
+* [SO 1102-7679](http://stackoverflow.com/q/11027679) &mdash;
+Store / Capture stdout and stderr in different variables (bash)
 
 No doubt there are many others too.

--- a/src/so-1203-0215/README.md
+++ b/src/so-1203-0215/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1203-0215
+
+[SO 1203-0215](http://stackoverflow.com/q/12030215) &mdash;
+Find duplicates across multiple tables

--- a/src/so-1251-5755/README.md
+++ b/src/so-1251-5755/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1251-5755
+
+[SO 1251-5755](http://stackoverflow.com/q/12515755) &mdash;
+Efficient list compacting

--- a/src/so-1313-2270/README.md
+++ b/src/so-1313-2270/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1313-2270
+
+[SO 1313-2270](http://stackoverflow.com/q/13132270) &mdash;
+How to select similar sets in SQL

--- a/src/so-1321-3864/README.md
+++ b/src/so-1321-3864/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1321-3864
+
+[SO 1321-3864](http://stackoverflow.com/q/13213864) &mdash;
+Multiprocessing and Pipes in C

--- a/src/so-1348-4943/README.md
+++ b/src/so-1348-4943/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1348-4943
+
+[SO 1348-4943](http://stackoverflow.com/q/13484943) &mdash;
+Print a binary tree in a pretty way

--- a/src/so-1363-6252/README.md
+++ b/src/so-1363-6252/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1363-6252
+
+[SO 1363-6252](http://stackoverflow.com/q/13636252) &mdash;
+C Minishell Adding Pipelines

--- a/src/so-1365-4397/README.md
+++ b/src/so-1365-4397/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1365-4397
+
+[SO 1365-4397](http://stackoverflow.com/q/13654397) &mdash;
+I need to read a matrix from a file which we dont know the matrix dimensions

--- a/src/so-1369-3446/README.md
+++ b/src/so-1369-3446/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1369-3446
+
+[SO 1369-3446](http://stackoverflow.com/q/13693446) &mdash;
+trying to run &quot;ls | grep r&quot; with &quot;execvp()&quot;

--- a/src/so-1390-5948/README.md
+++ b/src/so-1390-5948/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1390-5948
+
+[SO 1390-5948](http://stackoverflow.com/q/13905948) &mdash;
+C fork and pipe program with non-deterministic output

--- a/src/so-1431-2939/README.md
+++ b/src/so-1431-2939/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1431-2939
+
+[SO 1431-2939](http://stackoverflow.com/q/14312939) &mdash;
+Unix pipe - reading data from stdin in the child descriptor

--- a/src/so-1454-4920/README.md
+++ b/src/so-1454-4920/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1454-4920
+
+[SO 1454-4920](http://stackoverflow.com/q/14544920) &mdash;
+How do I remove last few characters from a string in C

--- a/src/so-1482-4668/README.md
+++ b/src/so-1482-4668/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1482-4668
+
+[SO 1482-4668](http://stackoverflow.com/q/14824668) &mdash;
+Merge sort function

--- a/src/so-1544-2950/README.md
+++ b/src/so-1544-2950/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1544-2950
+
+[SO 1544-2950](http://stackoverflow.com/q/15442950) &mdash;
+Calling different programs with different options and different arguments for each option

--- a/src/so-1555-9979/README.md
+++ b/src/so-1555-9979/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1555-9979
+
+[SO 1555-9979](http://stackoverflow.com/q/15559979) &mdash;
+split file on Nth occurrence of delimiter

--- a/src/so-1567-3333/README.md
+++ b/src/so-1567-3333/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1567-3333
+
+[SO 1567-3333](http://stackoverflow.com/q/15673333) &mdash;
+what is the proper way to pipe when making a shell in C

--- a/src/so-1584-5060/README.md
+++ b/src/so-1584-5060/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1584-5060
+
+[SO 1584-5060](http://stackoverflow.com/q/15845060) &mdash;
+Pipestream and child processes

--- a/src/so-1585-8766/README.md
+++ b/src/so-1585-8766/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1585-8766
+
+[SO 1585-8766](http://stackoverflow.com/q/15858766) &mdash;
+Tilde expansion in quotes

--- a/src/so-1675-9337/README.md
+++ b/src/so-1675-9337/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1675-9337
+
+[SO 1675-9337](http://stackoverflow.com/q/16759337) &mdash;
+find a path to leaf equal to sum (not BST)

--- a/src/so-1718-2582/README.md
+++ b/src/so-1718-2582/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1718-2582
+
+[SO 1718-2582](http://stackoverflow.com/q/17182582) &mdash;
+scanf not printing or reading anything

--- a/src/so-1722-2568/README.md
+++ b/src/so-1722-2568/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1722-2568
+
+[SO 1722-2568](http://stackoverflow.com/q/17222568) &mdash;
+Send standard err to pipe

--- a/src/so-1839-0259/README.md
+++ b/src/so-1839-0259/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1839-0259
+
+[SO 1839-0259](http://stackoverflow.com/q/18390259) &mdash;
+Organising inconsistent values

--- a/src/so-1843-7779/README.md
+++ b/src/so-1843-7779/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1843-7779
+
+[SO 1843-7779](http://stackoverflow.com/q/18437779) &mdash;
+Do I need to do anything with a SIGCHLD handler if I am just using wait() to wait for 1 child to finish at a time?

--- a/src/so-1855-9403/README.md
+++ b/src/so-1855-9403/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1855-9403
+
+[SO 1855-9403](http://stackoverflow.com/q/18559403) &mdash;
+To check the E2BIG error condition in exec

--- a/src/so-1858-2446/README.md
+++ b/src/so-1858-2446/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1858-2446
+
+[SO 1858-2446](http://stackoverflow.com/q/18582446) &mdash;
+c program with pipes to excecute &quot;ps aux | grep firefox | tee processes.txt&quot;

--- a/src/so-1880-1547/README.md
+++ b/src/so-1880-1547/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1880-1547
+
+[SO 1880-1547](http://stackoverflow.com/q/18801547) &mdash;
+transform matrix 2D to 1D

--- a/src/so-1881-2266/README.md
+++ b/src/so-1881-2266/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1881-2266
+
+[SO 1881-2266](http://stackoverflow.com/q/18812266) &mdash;
+Merging sorted multiple files into 1 sorted file

--- a/src/so-1882-0288/README.md
+++ b/src/so-1882-0288/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1882-0288
+
+[SO 1882-0288](http://stackoverflow.com/q/18820288) &mdash;
+sorting based on key from a file

--- a/src/so-1886-3184/README.md
+++ b/src/so-1886-3184/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1886-3184
+
+[SO 1886-3184](http://stackoverflow.com/q/18863184) &mdash;
+How can I prevent (not react to) a segmentation fault?

--- a/src/so-1888-4251/README.md
+++ b/src/so-1888-4251/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1888-4251
+
+[SO 1888-4251](http://stackoverflow.com/q/18884251) &mdash;
+getaddrinfo, I am not getting any canonname

--- a/src/so-1892-3412/README.md
+++ b/src/so-1892-3412/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1892-3412
+
+[SO 1892-3412](http://stackoverflow.com/q/18923412) &mdash;
+Use strtok() and execute UNIX command in background

--- a/src/so-1892-8821/README.md
+++ b/src/so-1892-8821/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1892-8821
+
+[SO 1892-8821](http://stackoverflow.com/q/18928821) &mdash;
+Merge sort code debugging

--- a/src/so-1901-6840/README.md
+++ b/src/so-1901-6840/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1901-6840
+
+[SO 1901-6840](http://stackoverflow.com/q/19016840) &mdash;
+Using mergesort to sort linked lists

--- a/src/so-1920-0574/README.md
+++ b/src/so-1920-0574/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1920-0574
+
+[SO 1920-0574](http://stackoverflow.com/q/19200574) &mdash;
+Segmentation Fault in C, possibly on medium/large dynamically allocated arrays

--- a/src/so-1921-4293/README.md
+++ b/src/so-1921-4293/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1921-4293
+
+[SO 1921-4293](http://stackoverflow.com/q/19214293) &mdash;
+unable to modify global variable in c

--- a/src/so-1930-4085/README.md
+++ b/src/so-1930-4085/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1930-4085
+
+[SO 1930-4085](http://stackoverflow.com/q/19304085) &mdash;
+Backtracking in a adjacency matrix in C?

--- a/src/so-1936-1241/README.md
+++ b/src/so-1936-1241/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1936-1241
+
+[SO 1936-1241](http://stackoverflow.com/q/19361241) &mdash;
+C program with execvp cat doesn&#39;t take more than 150 lines input

--- a/src/so-1945-2971/README.md
+++ b/src/so-1945-2971/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1945-2971
+
+[SO 1945-2971](http://stackoverflow.com/q/19452971) &mdash;
+Array-size macro that rejects pointers

--- a/src/so-1947-1071/README.md
+++ b/src/so-1947-1071/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1947-1071
+
+[SO 1947-1071](http://stackoverflow.com/q/19471071) &mdash;
+Radix Sort Looping Bug

--- a/src/so-1960-7450/README.md
+++ b/src/so-1960-7450/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1960-7450
+
+[SO 1960-7450](http://stackoverflow.com/q/19607450) &mdash;
+Stack overflows although there is enough memory available

--- a/src/so-1972-7309/README.md
+++ b/src/so-1972-7309/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1972-7309
+
+[SO 1972-7309](http://stackoverflow.com/q/19727309) &mdash;
+Segmentation Fault While Sorting

--- a/src/so-1974-7644/README.md
+++ b/src/so-1974-7644/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1974-7644
+
+[SO 1974-7644](http://stackoverflow.com/q/19747644) &mdash;
+Shell, run four processes parallel

--- a/src/so-1982-5489/README.md
+++ b/src/so-1982-5489/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 1982-5489
+
+[SO 1982-5489](http://stackoverflow.com/q/19825489) &mdash;
+Forking and piping processes in c

--- a/src/so-2016-4204/README.md
+++ b/src/so-2016-4204/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2016-4204
+
+[SO 2016-4204](http://stackoverflow.com/q/20164204) &mdash;
+sorting based partition (like in quick-sort)

--- a/src/so-2027-1977/README.md
+++ b/src/so-2027-1977/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2027-1977
+
+[SO 2027-1977](http://stackoverflow.com/q/20271977) &mdash;
+Array sorting in C

--- a/src/so-2029-3405/README.md
+++ b/src/so-2029-3405/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2029-3405
+
+[SO 2029-3405](http://stackoverflow.com/q/20293405) &mdash;
+How can I make my recursive C program more efficient?

--- a/src/so-2034-2745/README.md
+++ b/src/so-2034-2745/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2034-2745
+
+[SO 2034-2745](http://stackoverflow.com/q/20342745) &mdash;
+bit shifting and weird output

--- a/src/so-2083-1765/README.md
+++ b/src/so-2083-1765/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2083-1765
+
+[SO 2083-1765](http://stackoverflow.com/q/20831765) &mdash;
+Find difference between two dates in bash

--- a/src/so-2087-5751/README.md
+++ b/src/so-2087-5751/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2087-5751
+
+[SO 2087-5751](http://stackoverflow.com/q/20875751) &mdash;
+Page Not Found

--- a/src/so-2087-5751/README.md
+++ b/src/so-2087-5751/README.md
@@ -1,4 +1,4 @@
 ### Stack Overflow Question 2087-5751
 
-[SO 2087-5751](http://stackoverflow.com/q/20875751) &mdash;
-Page Not Found
+[SO 2087-5751](http://stackoverflow.com/q/20875751) &mdash; (deleted)
+Implement "finding the Nth largest number in an array"

--- a/src/so-2088-9460/README.md
+++ b/src/so-2088-9460/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2088-9460
+
+[SO 2088-9460](http://stackoverflow.com/q/20889460) &mdash;
+How do I run the preprocessor on local headers only?

--- a/src/so-2093-8023/README.md
+++ b/src/so-2093-8023/README.md
@@ -1,4 +1,4 @@
 ### Stack Overflow Question 2093-8023
 
-[SO 2093-8023](http://stackoverflow.com/q/20938023) &mdash;
-Page Not Found
+[SO 2093-8023](http://stackoverflow.com/q/20938023) &mdash; (deleted)
+Find Kth minimum element with quickSelect algorithm

--- a/src/so-2093-8023/README.md
+++ b/src/so-2093-8023/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2093-8023
+
+[SO 2093-8023](http://stackoverflow.com/q/20938023) &mdash;
+Page Not Found

--- a/src/so-2240-1091/README.md
+++ b/src/so-2240-1091/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2240-1091
+
+[SO 2240-1091](http://stackoverflow.com/q/22401091) &mdash;
+Bash variable substitution vs dirname and basename

--- a/src/so-2767-9013/README.md
+++ b/src/so-2767-9013/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2767-9013
+
+[SO 2767-9013](http://stackoverflow.com/q/27679013) &mdash;
+Insert a word into a binary search tree C

--- a/src/so-2773-3348/README.md
+++ b/src/so-2773-3348/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2773-3348
+
+[SO 2773-3348](http://stackoverflow.com/q/27733348) &mdash;
+Call a function without argument, although it needs one [K&amp;R-C]

--- a/src/so-2801-0892/README.md
+++ b/src/so-2801-0892/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2801-0892
+
+[SO 2801-0892](http://stackoverflow.com/q/28010892) &mdash;
+Circular Queue using Linked List

--- a/src/so-2969-1159/README.md
+++ b/src/so-2969-1159/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 2969-1159
+
+[SO 2969-1159](http://stackoverflow.com/q/29691159) &mdash;
+Making a shared data structure in c

--- a/src/so-3000-5033/README.md
+++ b/src/so-3000-5033/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3000-5033
+
+[SO 3000-5033](http://stackoverflow.com/q/30005033) &mdash;
+Adding to the head in a doubly linked list

--- a/src/so-3029-4129/README.md
+++ b/src/so-3029-4129/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3029-4129
+
+[SO 3029-4129](http://stackoverflow.com/q/30294129) &mdash;
+I need a mix of strtok and strtok_single

--- a/src/so-3038-8085/README.md
+++ b/src/so-3038-8085/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3038-8085
+
+[SO 3038-8085](http://stackoverflow.com/q/30388085) &mdash;
+How to use UTF-8 in C code?

--- a/src/so-3040-9127/README.md
+++ b/src/so-3040-9127/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3040-9127
+
+[SO 3040-9127](http://stackoverflow.com/q/30409127) &mdash;
+How can I print out the questions the user got wrong and the questions the user got correct (separately) after completing a quiz in python?

--- a/src/so-3049-3198/README.md
+++ b/src/so-3049-3198/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3049-3198
+
+[SO 3049-3198](http://stackoverflow.com/q/30493198) &mdash;
+Example why someone should use triple-pointers in C/C++?

--- a/src/so-3079-4962/README.md
+++ b/src/so-3079-4962/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3079-4962
+
+[SO 3079-4962](http://stackoverflow.com/q/30794962) &mdash;
+How to return positive occurrence

--- a/src/so-3109-6894/README.md
+++ b/src/so-3109-6894/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3109-6894
+
+[SO 3109-6894](http://stackoverflow.com/q/31096894) &mdash;
+How can I use Bit-Fields to save memory?

--- a/src/so-3246-0033/README.md
+++ b/src/so-3246-0033/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3246-0033
+
+[SO 3246-0033](http://stackoverflow.com/q/32460033) &mdash;
+Two children of same parent are not communicating using pipe if parent do not call wait()

--- a/src/so-3257-8455/README.md
+++ b/src/so-3257-8455/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3257-8455
+
+[SO 3257-8455](http://stackoverflow.com/q/32578455) &mdash;
+swap in doubly linked list

--- a/src/so-3310-4874/README.md
+++ b/src/so-3310-4874/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3310-4874
+
+[SO 3310-4874](http://stackoverflow.com/q/33104874) &mdash;
+How to pass result of query to function being part of the same?

--- a/src/so-3442-6337/README.md
+++ b/src/so-3442-6337/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3442-6337
+
+[SO 3442-6337](http://stackoverflow.com/q/34426337) &mdash;
+How to fix this non-recursive odd-even-merge sort algorithm?

--- a/src/so-3442-6734/README.md
+++ b/src/so-3442-6734/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3442-6734
+
+[SO 3442-6734](http://stackoverflow.com/q/34426734) &mdash;
+Page Not Found

--- a/src/so-3442-6734/README.md
+++ b/src/so-3442-6734/README.md
@@ -1,4 +1,4 @@
 ### Stack Overflow Question 3442-6734
 
-[SO 3442-6734](http://stackoverflow.com/q/34426734) &mdash;
-Page Not Found
+[SO 3442-6734](http://stackoverflow.com/q/34426734) &mdash; (deleted)
+Given array A consisting of N integers, return the size of the largest set S[K] for the array

--- a/src/so-3567-8399/README.md
+++ b/src/so-3567-8399/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3567-8399
+
+[SO 3567-8399](http://stackoverflow.com/q/35678399) &mdash;
+How to output a marquee string that is smaller than the size of the marquee sign?

--- a/src/so-3666-8295/README.md
+++ b/src/so-3666-8295/README.md
@@ -1,4 +1,4 @@
 ### Stack Overflow Question 3666-8295
 
-[SO 3666-8295](http://stackoverflow.com/q/36668295) &mdash;
-Page Not Found
+[SO 3666-8295](http://stackoverflow.com/q/36668295) &mdash; (deleted)
+Program in C to convert POSTFIX to INFIX

--- a/src/so-3666-8295/README.md
+++ b/src/so-3666-8295/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3666-8295
+
+[SO 3666-8295](http://stackoverflow.com/q/36668295) &mdash;
+Page Not Found

--- a/src/so-3668-2576/README.md
+++ b/src/so-3668-2576/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3668-2576
+
+[SO 3668-2576](http://stackoverflow.com/q/36682576) &mdash;
+Post Order print without recursion

--- a/src/so-3687-7867/README.md
+++ b/src/so-3687-7867/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3687-7867
+
+[SO 3687-7867](http://stackoverflow.com/q/36877867) &mdash;
+Proper manipulation of wide char/string in C

--- a/src/so-3709-2445/README.md
+++ b/src/so-3709-2445/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3709-2445
+
+[SO 3709-2445](http://stackoverflow.com/q/37092445) &mdash;
+Control the order of the threads ending

--- a/src/so-3710-6523/README.md
+++ b/src/so-3710-6523/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3710-6523
+
+[SO 3710-6523](http://stackoverflow.com/q/37106523) &mdash;
+C trie trying to add apostrophe

--- a/src/so-3724-7273/README.md
+++ b/src/so-3724-7273/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3724-7273
+
+[SO 3724-7273](http://stackoverflow.com/q/37247273) &mdash;
+How to evaluate a variable inside a variable bash scripting?

--- a/src/so-3757-7522/README.md
+++ b/src/so-3757-7522/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3757-7522
+
+[SO 3757-7522](http://stackoverflow.com/q/37577522) &mdash;
+Stack-overflow using recursion in C

--- a/src/so-3775-3785/README.md
+++ b/src/so-3775-3785/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3775-3785
+
+[SO 3775-3785](http://stackoverflow.com/q/37753785) &mdash;
+Regex repeating string

--- a/src/so-3799-7620/README.md
+++ b/src/so-3799-7620/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3799-7620
+
+[SO 3799-7620](http://stackoverflow.com/q/37997620) &mdash;
+Taking comma delimited data and creating a column for each section, while specifying in other rows when the section is not present

--- a/src/so-3804-4987/README.md
+++ b/src/so-3804-4987/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3804-4987
+
+[SO 3804-4987](http://stackoverflow.com/q/38044987) &mdash;
+How can I replace the URL-encoded sequences from a string in a C program?

--- a/src/so-3807-9550/README.md
+++ b/src/so-3807-9550/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3807-9550
+
+[SO 3807-9550](http://stackoverflow.com/q/38079550) &mdash;
+C - Moving a node in a linked list

--- a/src/so-3842-7289/README.md
+++ b/src/so-3842-7289/README.md
@@ -1,0 +1,4 @@
+### Stack Overflow Question 3842-7289
+
+[SO 3842-7289](http://stackoverflow.com/q/38427289) &mdash;
+More perlish way to sort string with leading floating point number?


### PR DESCRIPTION
The add-readme.sh script uses curl (twice, to get by a redirect) to get
the title of an SO question.
The script is currently unparameterized, though it does not overwrite
pre-existing README.md files.

Add 100 previously non-existent README.md files.

 Title information for five questions deleted on SO.

Five of the questions on SO were deleted and hence didn't show up with
`curl` because of no credentials (requires 10K rep to see them).
Manual transcription of paraphrase of question titles, plus note that
they are deleted.
