### PR TITLE
SO 2088-9460: Revise build and lose system-headers directory

### DIFF
--- a/etc/soq-tail.mk
+++ b/etc/soq-tail.mk
@@ -3,8 +3,11 @@
 # Provides target 'clean' to do sensible cleaning.
 # Relies on user to set macro PROGRAMS (plural) for removing programs.
 # Assumes etc/soq-head.mk is already included.
-# OUTFILES is set per makefile to hold output file names that should be
-# cleaned.
+# OUTFILES can be set per makefile to hold output file names that should
+# be cleaned.  OUTDIRS can be set per makefile to hold output directory
+# names that should be cleaned.
+# .dSYM directories are an artefact of building single-file programs on
+# .Mac OS X (or using dsymutil).
 
 .DEFAULT:
 	@echo "No commands specified for building $@"
@@ -12,4 +15,4 @@
 clean:
 	${RM_F} *.o *.a ${DEBRIS} ${OUTFILES}
 	${RM_F} ${PROGRAMS}
-	${RM_FR} *.dSYM
+	${RM_FR} *.dSYM ${OUTDIRS}

--- a/src/so-2088-9460/.gitignore
+++ b/src/so-2088-9460/.gitignore
@@ -1,3 +1,4 @@
 example
 listsyshdrs
 mksurrogates
+system-headers/

--- a/src/so-2088-9460/example.cpp
+++ b/src/so-2088-9460/example.cpp
@@ -2,5 +2,6 @@
 #include "class_a.hpp"  //local
 #include <string>       //system
 #include "class_b.hpp"  //local
+#include <algorithm>    //system
 
 int main() {}

--- a/src/so-2088-9460/makefile
+++ b/src/so-2088-9460/makefile
@@ -10,13 +10,30 @@ PROGRAMS = ${PROG1} ${PROG2} ${PROG3}
 
 all: ${PROGRAMS}
 
+HEADER1   = class_a.hpp
+HEADER2   = class_b.hpp
+HEADERS   = ${HEADER1} ${HEADER2}
+SOURCE    = example.cpp
+
+MKPATH    = mkdir -p
+SYSHDRDIR = system-headers
+
+.PHONY: make-surrogates test
+
+make-surrogates:	${PROG2} ${PROG3} ${SOURCE} ${HEADERS}
+	${MKPATH} ${SYSHDRDIR}
+	${PROG3} $$(${PROG2} ${SOURCE} ${HEADERS})
+
+# Clean-up
+OUTDIRS = ${SYSHDRDIR}
+
 # GNU Make manages to interpret this OK, but RMK truncates at the `#`.
 # Is there a sensible way to fix this?
 # How does GNU Make handle strings vs comments?
 # Is it 'white space before #'?
 
-test:
-	${CXX} -E -D'include=#include' -I. -Isystem-headers example.cpp | \
+test: make-surrogates
+	${CXX} -E -D'include=#include' -I. -I${SYSHDRDIR} example.cpp | \
 	grep -v '^# [0-9]'
 
 include ../../etc/soq-tail.mk

--- a/src/so-2088-9460/system-headers/algorithm
+++ b/src/so-2088-9460/system-headers/algorithm
@@ -1,1 +1,0 @@
-include <algorithm>

--- a/src/so-2088-9460/system-headers/iostream
+++ b/src/so-2088-9460/system-headers/iostream
@@ -1,1 +1,0 @@
-include <iostream>

--- a/src/so-2088-9460/system-headers/string
+++ b/src/so-2088-9460/system-headers/string
@@ -1,1 +1,0 @@
-include <string>


### PR DESCRIPTION
The `system-headers` directory and its checked-in contents (3 one-line files) really wasn't needed.  The `makefile` has been revised to build create and populate the directory on demand.  The example code includes `<algorithm>` too (the original did not).  And the main `soq-tail.mk` file now removes directories listed in `${OUTDIRS}` parallel to removing files listed in `${OUTFILES}`.  The `system-headers` directory is therefore ignored, now.

The `makefile` assumes that `mkdir -p` creates a directory if necessary and is silent (and successful) if the directory already exists, though a marginally more complex set of rules could use plain `mkdir` if someone was really worried about portability.