### PR TITLE
SO 3905-6574: Refine valgrind suppression Leak-029

### DIFF
--- a/etc/suppressions
+++ b/etc/suppressions
@@ -513,7 +513,6 @@
    fun:malloc
    fun:__parsefloat_buf
    fun:__svfscanf_l
-   fun:vsscanf_l
 }
 
 {


### PR DESCRIPTION
SO 3905-6574 shows a test case where the leak designated by
Mac-OS-X-10.11.5-Leak-029 in etc/suppressions is too stringent by one
level of function call.  Remove the extra level of function call.