### PR TITLE
src/matrices: increase size of matrices in matmul89.c, matmul99.c

### DIFF
--- a/src/matrices/matmul89.c
+++ b/src/matrices/matmul89.c
@@ -1,10 +1,19 @@
 /* SO 17192011 */
 #include <stdio.h>
 
-#define N 2
-static float m1[N][N] = {{1.0, -0.02}, {0.0, 1.0}};
-static float m2[N][1] = {{1.5f}, {1.5f}};
-static float result[1][N];
+static float m1[3][4] =
+{
+    { +1.0F, -0.02F, +0.76F, +3.14F },
+    { +0.0F, +1.97F, +2.13F, +0.21F },
+    { +4.1F, -1.37F, -1.00F, -2.11F },
+};
+static float m2[4][2] =
+{
+    { +1.50F, -7.22F },
+    { +2.31F, +1.99F },
+    { -0.77F, +4.72F },
+    { -3.41F, -5.26F },
+};
 
 void matrix_multiply(float *matrix1, float *matrix2, int m, int p, int n, float *output);
 void matrix_print(const char *tag, int m, int n, float *matrix);
@@ -12,10 +21,11 @@ void matrix_zero(float *matrix, int n, int m);
 
 int main(void)
 {
-    matrix_multiply(&m1[0][0], &m2[0][0], N, N, 1, &result[0][0]);
-    matrix_print("m1", N, N, &m1[0][0]);
-    matrix_print("m2", N, 1, &m2[0][0]);
-    matrix_print("m3", 1, N, &result[0][0]);
+    float result[3][2];
+    matrix_multiply(&m1[0][0], &m2[0][0], 3, 4, 2, &result[0][0]);
+    matrix_print("m1", 3, 4, &m1[0][0]);
+    matrix_print("m2", 4, 2, &m2[0][0]);
+    matrix_print("m3", 3, 2, &result[0][0]);
     return 0;
 }
 
@@ -25,13 +35,6 @@ void matrix_zero(float *matrix, int n, int m)
     for (i = 0; i < m; i++)
         for (j = 0; j < n; j++)
             matrix[i*n+j] = 0.0;
-    /* Or
-    for (i = 0; i < m * n; i++)
-        matrix[i] = 0.0;
-    */
-    /* Or even
-    memset(matrix, '\0', n * m * sizeof(float));
-    */
 }
 
 /*
@@ -62,10 +65,10 @@ void matrix_print(const char *tag, int m, int n, float *matrix)
     printf("%s (%d x %d):\n", tag, m, n);
     for (i = 0; i < m; i++)
     {
-        const char *pad = "[";
+        const char *pad = "[ ";
         for (j = 0; j < n; j++)
         {
-            printf("%s%6.3f", pad, matrix[i*n+j]);
+            printf("%s%+7.3f", pad, matrix[i*n+j]);
             pad = ", ";
         }
         printf("%s", " ]\n");

--- a/src/matrices/matmul99.c
+++ b/src/matrices/matmul99.c
@@ -1,25 +1,36 @@
 /* SO 17192011 */
 #if defined(__cplusplus)
-#error "This code uses VLA and cannot be compiled under C++"
+#error "This code uses VLA and should not compile under C++"
 #endif
 
 #include <stdio.h>
 
-#define N 2
-static float m1[N][N] = {{1.0, -0.02}, {0.0, 1.0}};
-static float m2[N][1] = {{1.5f}, {1.5f}};
-static float result[1][N];
+static float m1[3][4] =
+{
+    { +1.0F, -0.02F, +0.76F, +3.14F },
+    { +0.0F, +1.97F, +2.13F, +0.21F },
+    { +4.1F, -1.37F, -1.00F, -2.11F },
+};
+static float m2[4][2] =
+{
+    { +1.50F, -7.22F },
+    { +2.31F, +1.99F },
+    { -0.77F, +4.72F },
+    { -3.41F, -5.26F },
+};
 
-void matrix_multiply(int m, int p, int n, float matrix1[m][p], float matrix2[p][n], float output[m][n]);
+void matrix_multiply(int m, int p, int n, float matrix1[m][p],
+                     float matrix2[p][n], float output[m][n]);
 void matrix_print(const char *tag, int m, int n, float matrix[m][n]);
 void matrix_zero(int m, int n, float matrix[m][n]);
 
 int main(void)
 {
-    matrix_multiply(N, N, 1, m1, m2, result);
-    matrix_print("m1", N, N, m1);
-    matrix_print("m2", N, 1, m2);
-    matrix_print("m3", 1, N, result);
+    float result[3][2];
+    matrix_multiply(3, 4, 2, m1, m2, result);
+    matrix_print("m1", 3, 4, m1);
+    matrix_print("m2", 4, 2, m2);
+    matrix_print("m3", 3, 2, result);
 }
 
 void matrix_zero(int m, int n, float matrix[m][n])
@@ -29,7 +40,8 @@ void matrix_zero(int m, int n, float matrix[m][n])
             matrix[i][j] = 0.0;
 }
 
-void matrix_multiply(int m, int p, int n, float matrix1[m][p], float matrix2[p][n], float output[m][n])
+void matrix_multiply(int m, int p, int n, float matrix1[m][p],
+                     float matrix2[p][n], float output[m][n])
 {
     matrix_zero(m, n, output);
 
@@ -44,10 +56,10 @@ void matrix_print(const char *tag, int m, int n, float matrix[m][n])
     printf("%s (%d x %d):\n", tag, m, n);
     for (int i = 0; i < m; i++)
     {
-        char *pad = "[";
+        char *pad = "[ ";
         for (int j = 0; j < n; j++)
         {
-            printf("%s%6.3f", pad, matrix[i][j]);
+            printf("%s%+7.3f", pad, matrix[i][j]);
             pad = ", ";
         }
         printf("%s", " ]\n");


### PR DESCRIPTION
Change from multiplying a 2x2 and a 2x1 matrix (yielding a 1x2 matrix)
to multiplying a 3x4 and a 4x2 matrix (yielding a 3x2 matrix).
Adjust formatting slightly.  The matrices are all allocated as
regular (non-VLA) arrays - but the manipulation in matmul99.c
uses VLAs in the functions.  The programs use the same data
and produce the same result, but the processing is somewhat
different, of necessity.