### PR TITLE
src/matrices: vlamat.c - set array dimensions from command line

### DIFF
--- a/src/matrices/README.md
+++ b/src/matrices/README.md
@@ -15,6 +15,12 @@ underlying access mechanics are different, though.
 * `matmul89.c` &mdash; variable-dimension 2D array multiplication in strict C89.
 * `matmul99.c` &mdash; variable-dimension 2D array multiplication in C99 using VLA.
 
+These programs show the difference between coding in C89 and C99 for
+variable size arrays.
+The C89 code uses a simple pointer to `float` and explicitly computes
+the subscript corresponding to a given row and column number.
+The C99 code simply uses the row and column subscripts.
+
 ### SO 1857-9583
 
 There are multiple answers for the question.
@@ -42,6 +48,9 @@ failure.
 
 * `2da.c` &mdash; memory allocation for a 2D array of arrays with negative indices.
 
+This code allocates an array and then adjusts things so that it is legitimate to
+use negative indexes into the array.
+
 ### SO 3256-5694
 
 * `vlastruct.c` &mdash; another variable-dimension 2D array multiplication in C99 using VLA. 
@@ -49,4 +58,20 @@ failure.
 ### SO 3259-8224
 
 * `vlamat.c` &mdash; and another variable-dimension 2D array multiplication in C99 using VLA.
+
+This code accepts 3 command line arguments, all of which must be numbers
+in the range 1..99.
+These control the size of the arrays worked with.
+If the arguments are N1, N2, N3, then the size of the first matrix is
+N1xN2, the size of the second is N2xN3, and the size of the result
+(obviously) is N1xN3.
+With any other number of arguments, the code runs with N1 = 3, N2 = 5,
+N3 = 4.
+
+### `mda.c`
+
+The code in `mda.c` is not operational (it crashes).
+It's an attempt to code up arbitrary dimensional arrays (e.g. 3D or 4D
+or 5D) using a single structure, though there are numerous issues still
+to resolve.
 

--- a/src/matrices/vlamat.c
+++ b/src/matrices/vlamat.c
@@ -3,12 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef struct
-{
-    int nr, nc;
-    void *data;     // Actually double a[nr][nc]
-} Matrix;
-
 static double variant1(int nr, int nc, int r, int c)
 {
     assert(nr != 0);
@@ -33,7 +27,7 @@ static void mat_init(int nr, int nc, double m[nr][nc], Initializer init)
         {
             double v = init(nr, nc, i, j);
             m[i][j] = v;
-            printf(" %6.1f", v);
+            printf(" %6.0f", v);
         }
         putchar('\n');
     }
@@ -47,7 +41,7 @@ static void mat_dump(const char *tag, int nr, int nc, double m[nr][nc])
     {
         printf("[%d]:", i);
         for (int j = 0; j < nc; j++)
-            printf(" %6.1f", m[i][j]);
+            printf(" %6.0f", m[i][j]);
         putchar('\n');
     }
 }
@@ -72,12 +66,19 @@ static void mat_multiply(int r1, int c1, double m1[r1][c1],
     }
 }
 
-int main(void)
+int main(int argc, char **argv)
 {
     int r1 = 3;
     int c1 = 5;
-    int r2 = c1;
     int c2 = 4;
+    if (argc == 4)
+    {
+        r1 = atoi(argv[1]);
+        c1 = atoi(argv[2]);
+        c2 = atoi(argv[3]);
+        assert(r1 > 0 && r1 < 100 && c1 > 0 && c1 < 100 && c2 > 0 && c2 < 100);
+    }
+    int r2 = c1;
     int r3 = r1;
     int c3 = c2;
 


### PR DESCRIPTION
Primary change allows vlamat.c to be run with 3 arguments to control the size of the array.  If the 3 arguments are N1, N2, N3 (each in the range 1..99), then the program will create an array of size N1xN2, another of size N2xN3, and a result matrix of size N1xN3.  If there aren't 3 arguments, the size will be N1 = 3, N2 = 5, N3 = 4.

Also tweak content of README file.