### PR TITLE
Multiple improvements to multiple README.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.a
+*.bak
 *.bundle
 *.bz2
 *.dSYM
@@ -7,6 +8,7 @@
 *.lz
 *.o
 *.orig
+*.out
 *.so
 *.tar
 *.tgz
@@ -28,7 +30,6 @@ file
 file.[0-9]
 inc/*.h
 junk
-reversi
 script.awk
 script.sed
 script.sh

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Note that some questions have been deleted and therefore users with less
 than 10K of Stack Overflow reputation will not be able to see the
 referenced question.
 
-As of 2016-08-20, the repository is mostly stable, now.
-Most of the material is present in a separate source directory for each
+As of 2016-08-20, the repository is mostly stable.
+Most of the material is present with a separate source directory for each
 question, such as src/so-3567-8399.
 There are some exceptions to this in the src directory, with composite
 directories containing code related to multiple SO questions, or no SO

--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ number abcdwxyz is saved in src/so-abcd-wxyz (e.g. the code for [SO
 `src/so-3333-8314`).
 Note that SO does not recognize the punctuation in the number.
 
-The `inc` top-level directory contains common headers (but the source
-for them is in `src/libsoq` and `src/libcs50` or other locations as
-appropriate).
-The `lib` top-level directory contains the compiled libraries of common
-code (but the source for it is in `src/libsoq` and `src/libcs50`).
+The `inc` top-level directory is the directory where common headers are
+installed (but the source for them is in `src/libsoq` and `src/libcs50`
+or other locations as appropriate).
+Similarly, the `lib` top-level directory contains the installed
+libraries of common code (but the source for it is in `src/libsoq` and
+`src/libcs50`).
+The headers and libraries are installed by running `make install` in the
+relevant source directories.
+
 The `etc` directory contains miscellaneous files, such as the common
 makefile control information and also [`valgrind`](http://valgrind.org/)
 suppressions file for Mac OS X 10.11.6.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,41 @@
 SOQ - Stack Overflow Questions
 ------------------------------
 
-A repository of material related to Stack Overflow
-(http://stackoverflow.com/) questions and answers.
+A repository of material related to [Stack
+Overflow](http://stackoverflow.com/) questions and answers, primarily
+those where [Jonathan
+Leffler](http://stackoverflow.com/users/15168/jonathan-leffler) has
+contributed.
+This is by no means a complete list of the questions or answers
+contributed; these are just the more interesting ones where some part of
+the contribution was placed under version control.
 
-As of 2016-07-13, the repository has undergone extensive reorganization.
-Most of the material is present in a source directory for each question,
-such as src/so-3567-8399.  There are exceptions to this, both in the src
-directory and in the top-level directory.  The exceptions in the top-level
-will ultimately be resolved by moving the material into an appropriate
-sub-directory under `src`.
+Note that some questions have been deleted and therefore users with less
+than 10K of Stack Overflow reputation will not be able to see the
+referenced question.
 
-For the time being, the directory names for answers are written as
-so-abcd-wxyz (e.g. so-3333-8314), and will be placed in the src directory.
+As of 2016-08-20, the repository is mostly stable, now.
+Most of the material is present in a separate source directory for each
+question, such as src/so-3567-8399.
+There are some exceptions to this in the src directory, with composite
+directories containing code related to multiple SO questions, or no SO
+question at all.
 
-The `inc` top-level directory contains common headers (but the source for them is in `src/libsoq`
-and `src/libcs50` or other locations as appropriate).  The `lib` top-level directory contains the
-compiled libraries of common code (but the source for it is in `src/libsoq` and `src/libcs50`).
+For the time being, the directory name for an answer to SO question
+number abcdwxyz is saved in src/so-abcd-wxyz (e.g. the code for [SO
+3333-8314](http://stackoverflow.com/q/33338314) is in the directory
+`src/so-3333-8314`).
+Note that SO does not recognize the punctuation in the number.
+
+The `inc` top-level directory contains common headers (but the source
+for them is in `src/libsoq` and `src/libcs50` or other locations as
+appropriate).
+The `lib` top-level directory contains the compiled libraries of common
+code (but the source for it is in `src/libsoq` and `src/libcs50`).
 The `etc` directory contains miscellaneous files, such as the common
-makefile control information and also [`valgrind`](http://valgrind.org/) suppressions
-file for Mac OS X 10.11.5 (which probably just requires a rebuild of `valgrind` that has not happened yet).
+makefile control information and also [`valgrind`](http://valgrind.org/)
+suppressions file for Mac OS X 10.11.6.
+
+<a href="http://stackoverflow.com/users/15168/jonathan-leffler">
+<img src="http://stackoverflow.com/users/flair/15168.png" width="208" height="58" alt="Profile for Jonathan Leffler at Stack Overflow, Q&amp;A for professional and enthusiast programmers" title="Profile for Jonathan Leffler at Stack Overflow, Q&amp;A for professional and enthusiast programmers">
+</a>

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,18 @@
 # Source directory
 
-Contains other directories, a makefile, and this README.
+Primarily contains other directories, some scripts, a makefile, and this README.
 
-Should not normally contain any other files.
+The scripts are:
+* `add-readme.sh` &mdash; add a README.md file to directories without one.
+  It gets the SO question title from SO (probably in the worst possible
+  way, but it works, just about).
+* `mkmk.sh` &mdash; create a skeleton makefile for directories without one.
+  It uses a command, `gitignore`, for which the source is not yet
+  present in GitHub (bug).
+* `updmkfile.sh` &mdash; add new answer directories to the makefile.
+  It uses a command, `mklist`, for which the source is not yet present
+  in GitHub (bug).
+
+One day, the scripts may be moved to a bin directory.
+
+It should not normally contain any other files.

--- a/src/libcs50/README.md
+++ b/src/libcs50/README.md
@@ -1,0 +1,21 @@
+# CS50 &mdash; Harvard's CS50 Course C Library
+
+The
+[CS50](https://www.edx.org/course/introduction-computer-science-harvardx-cs50x)
+course is an introductory computer science course from Harvard
+University as part of its edX program.
+It is available for self-study.
+
+There is a C library available at [CS50
+Library](https://manual.cs50.net/library/) which provides support
+functions for the course.
+
+* There is also the [CS50](http://cs50.stackexchange.com/) Stack
+* Exchange site dedicated to the course.
+
+<hr>
+
+The code in cs50.h and cs50.c is directly copied from the Harvard site.
+The `makefile` builds the library as a static archive.
+Using `make install` places the library and header in the correct
+directories so that other code using the library will compile correctly.

--- a/src/so-2438-7581/README.md
+++ b/src/so-2438-7581/README.md
@@ -1,4 +1,4 @@
-## SO 2438-7581 Can code for a library function be contained several times in an executable?
+## [SO 2438-7581](http://stackoverflow.com/q/24387581) Can code for a library function be contained several times in an executable?
 
 ### Question
 

--- a/src/so-3388-7484/README.md
+++ b/src/so-3388-7484/README.md
@@ -1,4 +1,4 @@
-### SO 3388-7484
+### [SO 3388-7484](http://stackoverflow.com/q/33887484)
 
 Code known not to compile because the Phased Test library is not yet
 available.

--- a/src/so-3495-9596/README.md
+++ b/src/so-3495-9596/README.md
@@ -3,7 +3,7 @@
 Miscellaneous bits of AVL tree code, all of them non-operational, and
 not written by Jonathan Leffler (and not yet debugged or rewritten).
 
-### SO 3495-9596
+### [SO 3495-9596](http://stackoverflow.com/q/34959596)
 
 This question is still on SO.
 
@@ -24,7 +24,7 @@ The official accepted answer is a self-answer:
   code is replace pointer to pointer by just pointer and update pointer
   by returning value.
 
-### SO 3611-6746
+### [SO 3611-6746](http://stackoverflow.com/q/36116746)
 
 * `avl-36116746.c`
   Deleted (but identified) question on SO.  Crashes.

--- a/src/so-3849-4701/README.md
+++ b/src/so-3849-4701/README.md
@@ -1,4 +1,4 @@
-## SO 3849-4701 Joining multiple files
+## [SO 3849-4701](http://stackoverflow.com/q/38494701) Joining multiple files
 
 The question asks about joining three files which can be done
 non-iteratively - hence three-file-solution.sh.

--- a/src/so-3901-5527/README.md
+++ b/src/so-3901-5527/README.md
@@ -1,4 +1,4 @@
-# SO 3901-5527 &mdash; Is it safe to rename files while using readdir?
+# [SO 3901-5527](http://stackoverflow.com/q/39015527) &mdash; Is it safe to rename files while using readdir?
 
 A simple question couched in terms of Perl rather than C.
 


### PR DESCRIPTION
Updated information in top-level README.md file.  Added README.md file for the libcs50 directory, with the info cribbed from the SO tag wiki (which I wrote in the first place).  Multiple other README.md file have an active URL to the corresponding SO question (where there was no link before). 