### PR TITLE
Merge branch: sphinx/factorial-c

### DIFF
--- a/src/miscellany/factorial.c
+++ b/src/miscellany/factorial.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <math.h>
+
+static inline void f_factorial(void)
+{
+    float factorial = 1.0;
+    for (int i = 1; i < 200; i++)
+    {
+        factorial *= i;
+        if (!isfinite(factorial))
+            break;
+        printf("%3d! = %20.14e\n", i, factorial);
+    }
+}
+
+static inline void d_factorial(void)
+{
+    double factorial = 1.0;
+    for (int i = 1; i < 200; i++)
+    {
+        factorial *= i;
+        if (!isfinite(factorial))
+            break;
+        printf("%3d! = %20.14e\n", i, factorial);
+    }
+}
+
+static inline void l_factorial(void)
+{
+    long double factorial = 1.0;
+    for (int i = 1; i < 300; i++)
+    {
+        factorial *= i;
+        if (!isfinite(factorial))
+            break;
+        printf("%3d! = %20.14Le\n", i, factorial);
+    }
+}
+
+int main(void)
+{
+    f_factorial();
+    putchar('\n');
+    d_factorial();
+    putchar('\n');
+    l_factorial();
+
+    return 0;
+}

--- a/src/miscellany/factorial.c
+++ b/src/miscellany/factorial.c
@@ -1,49 +1,86 @@
 #include <stdio.h>
 #include <math.h>
 
-static inline void f_factorial(void)
+static inline void f_print(int i, float f)
+{
+    printf("%3d! = %12.6e\n", i, f);
+}
+
+static inline void d_print(int i, double f)
+{
+    printf("%3d! = %20.14e\n", i, f);
+}
+
+static inline void l_print(int i, long double f)
+{
+    printf("%3d! = %20.14Le\n", i, f);
+}
+
+static inline int f_factorial(void)
 {
     float factorial = 1.0;
-    for (int i = 1; i < 200; i++)
+    float old_value = factorial;
+    int i;
+    for (i = 1; i < 200; i++)
     {
+        old_value = factorial;
         factorial *= i;
         if (!isfinite(factorial))
             break;
-        printf("%3d! = %20.14e\n", i, factorial);
+        if (i <= 12)
+            f_print(i, factorial);
     }
+    f_print(i - 1, old_value);
+    return i - 1;
 }
 
-static inline void d_factorial(void)
+static inline int d_factorial(int f_max)
 {
     double factorial = 1.0;
-    for (int i = 1; i < 200; i++)
+    double old_value = factorial;
+    int i;
+    for (i = 1; i < 200; i++)
     {
+        old_value = factorial;
         factorial *= i;
         if (!isfinite(factorial))
             break;
-        printf("%3d! = %20.14e\n", i, factorial);
+        if (i <= 12 || (i == f_max + 1 || i == f_max))
+            d_print(i, factorial);
     }
+    d_print(i - 1, old_value);
+    return i - 1;
 }
 
-static inline void l_factorial(void)
+static inline int l_factorial(int f_max, int l_max)
 {
     long double factorial = 1.0;
-    for (int i = 1; i < 300; i++)
+    long double old_value = factorial;
+    int i;
+    for (i = 1; i < 300; i++)
     {
+        old_value = factorial;
         factorial *= i;
         if (!isfinite(factorial))
             break;
-        printf("%3d! = %20.14Le\n", i, factorial);
+        if (i <= 12 ||
+            (i == f_max + 1 || i == f_max) ||
+            (i == l_max + 1 || i == l_max))
+            l_print(i, factorial);
     }
+    l_print(i - 1, old_value);
+    return i - 1;
 }
 
 int main(void)
 {
-    f_factorial();
+    int f_max = f_factorial();
     putchar('\n');
-    d_factorial();
+    int d_max = d_factorial(f_max);
     putchar('\n');
-    l_factorial();
+    int l_max = l_factorial(f_max, d_max);
+    putchar('\n');
+    printf("Maximum: %d!\n", l_max);
 
     return 0;
 }


### PR DESCRIPTION
Adds a C program that calculates factorials in C using float, double and long double.

On a Mac running macOS Sierra 10.12.2 with GCC 6.2.0, the 'long double' range stops at 3.412E+609, which is smaller than expected.  Is the 'isfinite' macro giving trouble?