### PR TITLE
Annotate SO 0612-7503

### DIFF
--- a/src/so-0612-7503/README.md
+++ b/src/so-0612-7503/README.md
@@ -2,3 +2,29 @@
 
 [SO 0612-7503](http://stackoverflow.com/q/06127503) &mdash;
 Shuffle array in C
+
+Note the discussions at:
+
+* [Fisher-Yates Shuffle](http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle)
+  on Wikipedia.
+* [Ben Pfaff's implementation](http://benpfaff.org/writings/clc/shuffle.html)
+  on his web site.
+* [The Danger of Naivete](http://www.codinghorror.com/blog/2007/12/the-danger-of-naivete.html)
+  on the Coding Horror blog site.
+* [Why does this simple shuffle algorithm produce biassed results?](http://stackoverflow.com/questions/859253)
+  on SO.
+* [Is this C implementation of Fisher-Yates shuffle correct?](https://stackoverflow.com/questions/3343797/)
+  on SO, especially the answer by Roland Ilig.
+
+No doubt there are many other relevant sources.
+For general purpose code, you probably need to use a custom random
+number generator rather than co-opting the sequence from `rand()`.
+For example, `nrand48()` allows each user (e.g. the shuffle code) to
+have an independent sequence of random numbers without interference by
+or to other code using random number generation.
+This is critical for high quality library functions.
+The choice of which such random number generator is up to the user.
+Consider the merits of `/dev/urandom` too — remembering that
+repeatability is not one of the merits.
+And on BSD-derived systems, `arc4random()` may be a good choice.
+

--- a/src/so-0612-7503/genshuffle.c
+++ b/src/so-0612-7503/genshuffle.c
@@ -64,6 +64,25 @@ static void dump_data(const char *tag, size_t size, const char *data[size])
         printf("%zu: [%s]\n", i, data[i]);
 }
 
+/* Based on example from https://blog.codinghorror.com/the-danger-of-naivete/ */
+static void danger_of_naivete(void)
+{
+    printf("The danger of naivete\n");
+    int count[322] = { 0 };
+    for (int i = 0; i < 1000000; i++)
+    {
+        int data[3] = { 1, 2, 3 };
+        shuffle(&data[0], 3, sizeof(data[0]), rand_int);
+        int n = (data[0] * 10 + data[1]) * 10 + data[2];
+        count[n]++;
+    }
+    for (int i = 0; i < 322; i++)
+    {
+        if (count[i] != 0)
+            printf("%d = %6d\n", i, count[i]);
+    }
+}
+
 int main(int argc, char **argv)
 {
     enum { MATRIX_DIM = 4 };
@@ -104,6 +123,8 @@ int main(int argc, char **argv)
     dump_data("Before", DATA_SIZE, data);
     shuffle(data, DATA_SIZE, sizeof(data[0]), rand_int);
     dump_data("After", DATA_SIZE, data);
+
+    danger_of_naivete();
 
     return 0;
 }


### PR DESCRIPTION
Add a bunch of URLs to the README.md file, referencing Wikipedia, Ben Pfaff's writings, Coding Horror blog, other SO questions.

Modify genshuffle.c — add a simulation of the 'shuffle 3-element array' code from The Danger of Naivete blog entry on Coding Horror to demonstrate that the shuffle is reasonably unbiassed.  Note that if the program is run with an argument, that is used as a seed.  Testing run repeatedly using:

    ./genshuffle $(randseed -b 4)

(where `randseed -b 4` returns 4 bytes hex-encoded read from `/dev/urandom`).  The results were satisfying to the eye: repeated sets of one million trials produced counts in the range 165782 .. 167343 for the 6 permutations, which is absolutely not the biassed distribution in 'The Danger' article.