### PR TITLE
Upgrade SO 29691159 - Manipulate shared memory segments

### DIFF
--- a/src/so-2969-1159/README.md
+++ b/src/so-2969-1159/README.md
@@ -1,4 +1,15 @@
 ### Stack Overflow Question 2969-1159
 
 [SO 2969-1159](http://stackoverflow.com/q/29691159) &mdash;
-Making a shared data structure in c
+Making a shared data structure in C
+
+The program `shm-master` allows you to simulate the basic management
+of a shared memory segment in most plausible sequences.
+
+[SO 4225-8485](http://stackoverflow.com/q/42258485) &mdash;
+Detaching from shared memory before removing it &mdash; asks about
+whether you can delete a shared memory segment while programs are
+using it.  Adding the `-t time` option to the code means that you
+can run `shm-master` in background, having it sleep after it has
+created or attached to a shared memory segment, and you can have
+multiple `shm-master` processes connected to it at the same time.

--- a/src/so-2969-1159/makefile
+++ b/src/so-2969-1159/makefile
@@ -9,7 +9,7 @@ PROGRAMS = ${PROG1} ${PROG2}
 
 all: ${PROGRAMS}
 
-FILES.c = shm-master.c so-stderr.c
+FILES.c = shm-master.c
 FILES.o = ${FILES.c:.c=.o}
 
 ${PROG1}: ${FILES.o}


### PR DESCRIPTION
Add sleep time to shm-master.c so that it can be run in background and operations performed while a process is attached to the shared memory segment.  Sleeping processes do not manipulate shared memory; that is a further step.