### PR TITLE
SO 3388-7484 and generic header changes

### DIFF
--- a/etc/soq-head.mk
+++ b/etc/soq-head.mk
@@ -4,7 +4,7 @@
 
 BASEDIR = ../..
 LIBDIR  = ${BASEDIR}/lib
-HDRDIR  = ${BASEDIR}/inc
+INCDIR  = ${BASEDIR}/inc
 
 SOQBASE = soq
 SOQNAME = lib${SOQBASE}.a
@@ -21,7 +21,7 @@ CS50PATH = ${LIBDIR}/${CS50NAME}
 
 CC     = gcc
 GFLAGS = -g
-IFLAGS = -I${HDRDIR}
+IFLAGS = -I${INCDIR}
 OFLAGS = -O3
 SFLAGS = -std=c11
 TFLAGS = # Set to -DTEST (or similar) when needed

--- a/src/libcs50/makefile
+++ b/src/libcs50/makefile
@@ -17,7 +17,7 @@ ${CS50NAME}:	${FILES.o}
 
 install: ${CS50NAME} ${FILES.h}
 	${CP} ${CPFLAGS} ${CS50NAME} ${LIBDIR}
-	${CP} ${CPFLAGS} ${FILES.h}  ${HDRDIR}
+	${CP} ${CPFLAGS} ${FILES.h}  ${INCDIR}
 
 clean:
 	${RM_F} ${DEBRIS} ${FILES.o}

--- a/src/libsoq/makefile
+++ b/src/libsoq/makefile
@@ -46,7 +46,7 @@ ${LIBNAME}:	${FILES.o}
 
 install: ${LIBNAME} ${FILES.h}
 	${CP} ${CPFLAGS} ${LIBNAME} ${LIBDIR}
-	${CP} ${CPFLAGS} ${FILES.h} ${HDRDIR}
+	${CP} ${CPFLAGS} ${FILES.h} ${INCDIR}
 
 PROGRAMS = ${FILES.c:.c=} ${AUXFILES.c:.c=}
 

--- a/src/so-3388-7484/README.md
+++ b/src/so-3388-7484/README.md
@@ -1,6 +1,31 @@
-### [SO 3388-7484](http://stackoverflow.com/q/33887484)
+### [SO 3388-7484](http://stackoverflow.com/q/33887484) &mdash; Fraction Arithmetic
 
-Code known not to compile because the Phased Test library is not yet
-available.
+This code is known not to compile in the GitHub environment because the
+Phased Test library is not yet available.
+In principle, I'm working on creating a sub-module or two for that
+(probably several).
 
-Working on creating a sub-module or two for that (probably several).
+<hr>
+
+This question is one that is not a very good fit for SO.
+It's a homework assignment.
+The homework specification describes one interface — three-argument
+functions taking two inputs and one output structure, all as pointers.
+The sample code flies against that specification, taking two structures
+as value parameters and returning one.
+Which set of rules should be followed?
+
+The code written here as so.33887484.[ch] corresponds to the stated
+specification rather than the sample code.
+
+The code written here as rational.c — which embeds the code that
+should be in the header rational.h — follows the sample code rather
+than the stated specification.
+It does not expose the GCD function.
+
+The arithmetic and printing code is straight-forward.
+As so often, the input scanning code is far, far trickier.
+
+The input code implemented accepts fixed point decimals (9.999), plain
+fractions (1/5) and proper fractions (1 3/4).
+

--- a/src/so-3388-7484/makefile
+++ b/src/so-3388-7484/makefile
@@ -2,11 +2,19 @@
 
 include ../../etc/soq-head.mk
 
+# This works on the development machine, but not yet via GitHub
+LDLIB2 = -ljl
+IFLAGS = -I${INCDIR} -I${HOME}/inc
+LDFLAGS = ${LDFLAG1} -L${HOME}/lib/64
+
+# At the moment, ratcalc includes so.33887484.c directly.
+# Clearly, this is not the long-term way; the code in so.33887484.c would be in a library.
+# Unless you believe in SQLite Amalgamations as the way to go for everything.
 PROG1 = ratcalc
 PROG2 = rational
-PROG3 = so.33887484
+#PROG3 = so.33887484
 
-PROGRAMS = ${PROG1} ${PROG2} ${PROG3}
+PROGRAMS = ${PROG1} ${PROG2} #${PROG3}
 
 all: ${PROGRAMS}
 

--- a/src/so-3388-7484/ratcalc.c
+++ b/src/so-3388-7484/ratcalc.c
@@ -75,7 +75,7 @@ int main(void)
                     break;
                 default:
                     printf("Invalid operation %c - try again\n", op);
-                    goto next_line;;
+                    goto next_line;
             }
             printf("res = %s (op = '%c')\n\n", ri_fmt(res, buffer, sizeof(buffer)), op);
             lhs = res;

--- a/src/so-3388-7484/rational.c
+++ b/src/so-3388-7484/rational.c
@@ -95,9 +95,9 @@ static void ri_chk(RationalInt val)
 RationalInt ri_new(int numerator, int denominator)
 {
     assert(denominator != 0);
-    assert(denominator != INT_MIN && denominator != INT_MIN);
+    assert(denominator != INT_MIN && numerator != INT_MIN);
     RationalInt ri;
-    /* Handle invalid inputs as 0 if assertions are not enabled */
+    /* Handle invalid inputs (and zero inputs) as 0 if assertions are not enabled */
     if (numerator   == 0 || numerator   == INT_MIN ||
         denominator == 0 || denominator == INT_MIN)
     {

--- a/src/so-3388-7484/so.33887484.h
+++ b/src/so-3388-7484/so.33887484.h
@@ -22,7 +22,7 @@ extern void ri_mod(const RationalInt *lhs, const RationalInt *rhs, RationalInt *
 ** If the user manually, explicitly initializes an improper
 ** RationalInt, then these may do something more interesting.
 */
-extern int  ri_gcd(const RationalInt *val);      /* Exercise in futility */
+extern int  ri_gcd(const RationalInt *val);     /* Exercise in futility */
 extern void ri_normalize(RationalInt *val);     /* Exercise in futility */
 
 extern char *ri_fmt(RationalInt val, char *buffer, size_t buflen);


### PR DESCRIPTION
Minor tarting up (mainly of the README.md file) in src/so-3388-7484.  Note that the code still does not compile for people who pull this from GitHub — the PhasedTest library has not yet been made available.

Rename HDRDIR to INCDIR in etc/soq-head.mk and then use it in three places (src/libsoq/makefile, src/libcs50/makefile, src/so-3388-7484/makefile).
