### PR TITLE
SO 4479-2794: Ignore __.SYMDEF SORTED

### DIFF
--- a/src/so-4479-2794/.gitignore
+++ b/src/so-4479-2794/.gitignore
@@ -1,3 +1,4 @@
+__.SYMDEF SORTED
 client-20170706
 config.h
 cpd-client


### PR DESCRIPTION
Extracted material from archive; got that hidden file left behind, so ignore it.