### PR TITLE
SO 5246-1162 Understanding wordexp

### DIFF
--- a/src/libsoq/escape.c
+++ b/src/libsoq/escape.c
@@ -1,0 +1,159 @@
+/*
+@(#)File:           escape.c
+@(#)Purpose:        Return escaped argument for passing to eval etc.
+@(#)Author:         J Leffler
+@(#)Copyright:      (C) JLSS 1990-2018
+@(#)Derivation:     escape.c 1.13 2018/08/18 17:27:36
+*/
+
+/*TABSTOP=4*/
+
+#include "escape.h"
+#include <stdlib.h>
+#include <string.h>
+
+static char    bstr[256];
+static char   *sstr = bstr;
+static size_t  slen = sizeof(bstr);
+
+char *escape(const char *s)
+{
+    char   *p;
+    char    c;
+    size_t  l = 4 * strlen(s) + 3;
+    if (l > slen)
+    {
+        if (sstr != bstr)
+            free(sstr);
+        if ((sstr = (char *)malloc(l)) == 0)  /*=C++=*/
+        {
+            sstr = bstr;
+            slen = sizeof(bstr);
+            return(0);
+        }
+        slen = l;
+    }
+
+    p = sstr;
+    *p++ = '\'';
+    while ((c = *s++) != '\0')
+    {
+        if (c == '\'')
+        {
+            *p++ = '\'';
+            *p++ = '\\';
+            *p++ = '\'';
+        }
+        *p++ = c;
+    }
+    *p++ = '\'';
+    *p   = '\0';
+
+    return(sstr);
+}
+
+size_t escape_chosen(const char *src, const char *ok, char *buffer, size_t buflen)
+{
+    size_t span = strspn(src, ok);
+    size_t len;
+    if (src[span] != '\0')
+    {
+        /* Need to escape it */
+        char *end = buffer + buflen - 2;
+        char *dst = buffer;
+        char  c;
+        *dst++ = '\'';
+        while ((c = *src++) != '\0' && dst < end)
+        {
+            if (c == '\'')
+            {
+                if (dst > end - 4)
+                    break;
+                *dst++ = '\'';
+                *dst++ = '\\';
+                *dst++ = '\'';
+            }
+            *dst++ = c;
+        }
+        if (c != '\0')
+        {
+            /* Insufficient space - how much more is needed */
+            while ((c = *src++) != '\0')
+            {
+                if (c == '\'')
+                    dst += 3;
+                dst++;
+            }
+            dst += 2;
+        }
+        else
+        {
+            *dst++ = '\'';
+            *dst = '\0';
+        }
+        len = (size_t)(dst - buffer);
+    }
+    else
+    {
+        len = strlen(src);
+        if (len < buflen - 1)
+            strcpy(buffer, src);
+    }
+    return(len);
+}
+
+const char escape_ok[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789-+=_.,/";
+
+size_t escape_always(const char *src, char *buffer, size_t buflen)
+{
+    return escape_chosen(src, "", buffer, buflen);
+}
+
+size_t escape_simple(const char *src, char *buffer, size_t buflen)
+{
+    return escape_chosen(src, escape_ok, buffer, buflen);
+}
+
+#if defined(TEST)
+
+#include <stdio.h>
+
+int main(void)
+{
+    char  buffer[BUFSIZ];
+    char *esc;
+    char  escbuff[4*BUFSIZ+3];
+    const char chosen[] = "abcABC123";
+
+    printf("Testing escape functions.  Enter a string.\n"
+           "Note that in this test, escape_chosen() escapes any string containing\n"
+           "characters other than: %s\n", chosen);
+    printf("Enter string to be escaped: ");
+    while (fgets(buffer, sizeof(buffer), stdin) != 0)
+    {
+        buffer[strlen(buffer) - 1] = '\0';  /* Zap newline */
+        esc = escape(buffer);
+        printf("Input  : %s\n", buffer);
+        printf("Escaped: %s\n", esc);
+        if (escape_always(buffer, escbuff, sizeof(escbuff)) > sizeof(escbuff))
+            printf("escape_always: buffer overflow!\n");
+        else
+            printf("escape_always: <<%s>>\n", escbuff);
+        if (escape_simple(buffer, escbuff, sizeof(escbuff)) > sizeof(escbuff))
+            printf("escape_simple: buffer overflow!\n");
+        else
+            printf("escape_simple: <<%s>>\n", escbuff);
+        if (escape_chosen(buffer, "abcABC123", escbuff, sizeof(escbuff)) > sizeof(escbuff))
+            printf("escape_chosen: buffer overflow!\n");
+        else
+            printf("escape_chosen: <<%s>>\n", escbuff);
+        printf("Enter string to be escaped: ");
+    }
+    putchar('\n');
+    return(0);
+}
+
+#endif /* TEST */

--- a/src/libsoq/escape.h
+++ b/src/libsoq/escape.h
@@ -1,0 +1,54 @@
+/*
+@(#)File:           escape.h
+@(#)Purpose:        Escape a string to protect against shell expansion
+@(#)Author:         J Leffler
+@(#)Copyright:      (C) JLSS 2005,2007-08,2012
+@(#)Derivation:     escape.h 1.5 2012/07/22 01:34:03
+*/
+
+/*TABSTOP=4*/
+
+#ifndef JLSS_ID_ESCAPE_H
+#define JLSS_ID_ESCAPE_H
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h> /* size_t */
+
+/*
+** escape() is not thread-safe and not re-entrant.  It always escapes
+** the argument. escape() returns a pointer to space which it manages
+** (initially statically allocated; dynamically allocated if there isn't
+** enough space in the static buffer) and reuses it on subsequent calls.
+*/
+extern char *escape(const char *s);
+
+/*
+** Thread-safe, re-entrant alternatives to classic escape() function.
+** escape_always() - escapes every string, putting single quote at start
+**                   and end, and replaces single quotes with quote,
+**                   backslash, quote, quote, just like the classic
+**                   escape() does.
+** escape_simple() - escapes a string only if it contains any characters
+**                   outside the set [-A-Za-z0-9_.,/] (basic file names
+**                   are left unescaped), which is found in escape_ok[].
+** escape_chosen() - escapes a string only if it contains any characters
+**                   outside the set specified as OK.  It ignores
+**                   attempts to claim that control characters, spaces
+**                   or backslashes are OK.
+** escape_always() is implemented as: escape_chosen(src, "", buffer, buflen);
+** escape_simple() is implemented as: escape_chosen(src, escape_ok, buffer, buflen);
+*/
+extern size_t escape_always(const char *src, char *buffer, size_t buflen);
+extern size_t escape_simple(const char *src, char *buffer, size_t buflen);
+extern size_t escape_chosen(const char *src, const char *ok, char *buffer, size_t buflen);
+
+extern const char escape_ok[];
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* JLSS_ID_ESCAPE_H */

--- a/src/libsoq/githeader.pl
+++ b/src/libsoq/githeader.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 #
 #   Convert JLSS RCS Heading to Git
+#   Use to convert latest version of code from lib/JL to SOQ
 
 use strict;
 use warnings;

--- a/src/libsoq/makefile
+++ b/src/libsoq/makefile
@@ -20,6 +20,7 @@ FILES.c = \
 	chkstrint.c \
 	debug.c \
 	emalloc.c \
+	escape.c \
 	filter.c \
 	gcd.c \
 	kludge.c \

--- a/src/so-5208-4867/README.md
+++ b/src/so-5208-4867/README.md
@@ -78,3 +78,20 @@ arguments are provided.
 
 It's a lot easier to get the data you want into `wordexp()` from
 standard input than it is via command line arguments.
+
+### `so-5246-1162-a.c`
+
+Original flawed code from SO 5246-1162.
+This crashes because `wordexp()` fails and the code dereferences a null
+pointer (to pointer to char).
+
+### `so-5246-1162-b.c`
+
+Revised code for SO 5246-1162.
+This doesn't crash and does diagnose a syntax error.
+
+### `esc11.c`
+
+Simple code using the `escape_simple()` function from `escape.c` and
+`escape.h` in the libsoq library.
+

--- a/src/so-5208-4867/esc11.c
+++ b/src/so-5208-4867/esc11.c
@@ -1,0 +1,26 @@
+/* SO 5246-1162 */
+#include <stdio.h>
+#include "escape.h"
+
+int main(void)
+{
+    static const char *words[] =
+    {
+        "'\"\"TEST\"\"'",
+        "\\''\\\"\"\"\\\"TEST1\\\"\"\"\\\"'\\'",
+        "'\\'\"\\\"\\\"\"TEST2\"\\\"\\\"\"\\''",
+    };
+    enum { NUM_WORDS = sizeof(words) / sizeof(words[0]) };
+
+    for (int i = 0; i < NUM_WORDS; i++)
+    {
+        printf("Word %d: [[%s]]\n", i, words[i]);
+        char buffer[256];
+        if (escape_simple(words[i], buffer, sizeof(buffer)) >= sizeof(buffer))
+            fprintf(stderr, "Escape failed - not enough space!\n");
+        else
+            printf("Escaped: [[%s]]\n", buffer);
+    }
+
+    return 0;
+}

--- a/src/so-5208-4867/input.data
+++ b/src/so-5208-4867/input.data
@@ -1,0 +1,3 @@
+*.c
+*[mM]*
+*.[ch] *[mM]* ~/.profile $HOME/.profile

--- a/src/so-5208-4867/makefile
+++ b/src/so-5208-4867/makefile
@@ -4,8 +4,10 @@ include ../../etc/soq-head.mk
 
 PROG1 = wexp19
 PROG2 = wexp79
+PROG3 = so-5246-1162-b
+PROG4 = esc11
 
-PROGRAMS = ${PROG1} ${PROG2}
+PROGRAMS = ${PROG1} ${PROG2} ${PROG3} ${PROG4}
 
 all: ${PROGRAMS}
 

--- a/src/so-5208-4867/so-5246-1162-a.c
+++ b/src/so-5208-4867/so-5246-1162-a.c
@@ -1,0 +1,24 @@
+/* SO 5246-1162 */
+#include <stdio.h>
+#include <wordexp.h>
+
+static void expansion_demo(char const *str)
+{
+  printf("Before expansion: %s\n", str);
+
+  wordexp_t exp;
+  wordexp(str, &exp, 0);
+  printf("After expansion: %s\n", exp.we_wordv[0]);
+  wordfree(&exp);
+}
+
+int main(void)
+{
+  char const *str1 = "\\''\\\"\"\"\\\"TEST1\\\"\"\"\\\"'\\'";
+  expansion_demo(str1);
+
+  char const *str2 = "'\\'\"\\\"\\\"\"TEST2\"\\\"\\\"\"\\''";
+  expansion_demo(str2);
+
+  return 0;
+}

--- a/src/so-5208-4867/so-5246-1162-b.c
+++ b/src/so-5208-4867/so-5246-1162-b.c
@@ -1,0 +1,48 @@
+/* SO 5246-1162 */
+#include <stdio.h>
+#include <wordexp.h>
+
+static const char *worderror(int errnum)
+{
+    switch (errnum)
+    {
+    case WRDE_BADCHAR:
+        return "One of the unquoted characters - <newline>, '|', '&', ';', '<', '>', '(', ')', '{', '}' - appears in an inappropriate context";
+    case WRDE_BADVAL:
+        return "Reference to undefined shell variable when WRDE_UNDEF was set in flags to wordexp()";
+    case WRDE_CMDSUB:
+        return "Command substitution requested when WRDE_NOCMD was set in flags to wordexp()";
+    case WRDE_NOSPACE:
+        return "Attempt to allocate memory in wordexp() failed";
+    case WRDE_SYNTAX:
+        return "Shell syntax error, such as unbalanced parentheses or unterminated string";
+    default:
+        return "Unknown error from wordexp() function";
+    }
+}
+
+static void expansion_demo(char const *str)
+{
+    printf("Before expansion: [%s]\n", str);
+    wordexp_t exp;
+    int rc;
+    if ((rc = wordexp(str, &exp, 0)) == 0)
+    {
+        for (size_t i = 0; i < exp.we_wordc; i++)
+            printf("After expansion %zu: [%s]\n", i, exp.we_wordv[i]);
+        wordfree(&exp);
+    }
+    else
+        printf("Expansion failed (%d: %s)\n", rc, worderror(rc));
+}
+
+int main(void)
+{
+    char const *str1 = "\\''\\\"\"\"\\\"TEST1\\\"\"\"\\\"'\\'";
+    expansion_demo(str1);
+
+    char const *str2 = "'\\'\"\\\"\\\"\"TEST2\"\\\"\\\"\"\\''";
+    expansion_demo(str2);
+
+    return 0;
+}


### PR DESCRIPTION
Showing problems with SO 5246-1162 code — and a misunderstanding of what `wordexp()` does.  Added `escape.c` and `escape.h` to `src/libsoq` and consequent makefile update.  Add code `so-5246-1162-a.c` (essentially verbatim copy of code from question SO 5246-1162), `so-5246-1162-b.c` (fixed code that reports an error), plus `esc11.c` (code that uses `escape_simple()` from `escape.[ch]` to do what I think the question wants to do.
