### PR TITLE
Remove one line from one suppression.

### DIFF
--- a/etc/suppressions-macos-10.13.4
+++ b/etc/suppressions-macos-10.13.4
@@ -225,5 +225,4 @@
    fun:malloc
    fun:__parsefloat_buf
    fun:__svfscanf_l
-   fun:vsscanf_l
 }


### PR DESCRIPTION
Remove the outermost line for a suppression, to capture other
contexts where the leak occurs.