### PR TITLE
Add K&R 1st and 2nd Edition URLs.

### DIFF
--- a/src/scripts/so-books.sh
+++ b/src/scripts/so-books.sh
@@ -56,4 +56,10 @@ K N King
 David R Hanson
 [C Interfaces and Implementations](https://smile.amazon.com/dp) 1996.
 
+Brian W Kernighan and Dennis M Ritchie
+[The C Programming Language, 2nd Edn](https://smile.amazon.com/dp/0131103628) 1988.
+
+Brian W Kernighan and Dennis M Ritchie
+[The C Programming Language, 1st Edn](https://smile.amazon.com/dp/0131101633) 1978.
+
 EOF


### PR DESCRIPTION
Add the canonical works on C to the URL list, even though there are grounds for being cautious about the second edition as a primary means of learning modern C (some of the material is dated, especially about the Unix interface), and the material in the first edition is only suitable for historical reference — it should not be used for learning modern C.  A decent alternative for learning modern(ish) C is King.