### PR TITLE
SO 5308-6674 - Protect against use outside 'next prime after'.

### DIFF
--- a/src/so-5308-6674/README.md
+++ b/src/so-5308-6674/README.md
@@ -5,7 +5,14 @@ A rhombus filled with prime numbers
 
 This question was deleted by the OP so it isn't necessarily visible.
 
-There are a couple of parts to the problem.
+See also:
+
+* [SO 5333-9734](https://stackoverflow.com/q/53339734) "Finding the
+   first prime number after the entered number"
+* [SO 53320995](https://stackoverflow.com/q/53320995) "Finding closest
+   prime number".
+
+There are a couple of parts to the rhombus problem.
 
 1. Establish a list of prime numbers, or a way to get the next prime number.
 2. Print a rhombus.
@@ -31,4 +38,3 @@ This code combines `npa67.c` and `rhom59.c` to produce an unsubmitted
 answer to the code problem.
 It adapts the number of digits printed to the size of rhombus, but the
 size boundaries are established empirically rather than calculated.
-

--- a/src/so-5308-6674/npa67.c
+++ b/src/so-5308-6674/npa67.c
@@ -7,6 +7,8 @@
 #include <limits.h>
 #include <stdbool.h>
 
+#define NEXT_PRIME_AFTER    /* Avoid unnecessary checks in is_prime() */
+
 #ifdef TEST
 static unsigned primes[] = { 2, 3, 5, 7, 11 };
 #else
@@ -34,10 +36,22 @@ static unsigned primes[] =
 
 enum { N_PRIMES = sizeof(primes) / sizeof(primes[0]) };
 
+/*
+** In the context of next_prime_after(), this function is never called
+** upon to validate small numbers - numbers less than primes[N_PRIMES-1]
+** are not passed here.  In more general contexts, the extra conditions
+** in the conditionally compiled code are necessary for accuracy.
+*/
 static bool is_prime(unsigned p)
 {
     for (int i = 0; i < N_PRIMES; i++)
     {
+#ifndef NEXT_PRIME_AFTER
+        if (p < primes[i])
+            return false;
+        if (p == primes[i])
+            return true;
+#endif /* NEXT_PRIME_AFTER */
         if (p % primes[i] == 0)
             return false;
     }


### PR DESCRIPTION
The code in isprime() is valid for the context of next_prime_after(),
but needs extra tests to be valid for small primes.  This conditionally
add those extra tests.

There is also code in soq/src/Primes (isprime.c) that is relevant and
similar.