### PR TITLE
SO 5332-1864: Add `ads41.c` using insertion sort.

### DIFF
--- a/src/so-5332-1864/README.md
+++ b/src/so-5332-1864/README.md
@@ -26,14 +26,19 @@ found anything definitive.
   * [Insertion sort](https://en.wikipedia.org/wiki/Insertion_sort)
   * [Selection sort](https://en.wikipedia.org/wiki/Selection_sort)
 
-  I think that the code may be a sub-optimal variant of selection sort;
-  it doesn't really correspond well with bubble sort of insertion sort.
-
 * `ads29.c`
 
   A working solution, using the generic merge sort code from [SO
   1802-8773: Merge Sort](https://github.com/jleffler/soq/tree/master/src/so-1882-8773)
-  and the file `ms41.c` in particular.
+  and the file `ms41.c` in particular.  That code could perhaps be
+  extracted into standalone source files — a header and source file.
+  NB: On macOS (BSD), the system `<stdlib.h>` declares `mergesort()`
+  with the same signature.
+
+* `ads41.c`
+
+  A working solution, using a generic insertion sort function based on
+  code from Bentley "Programming Pearls, 2nd Edn".
 
 * `ads47.c`
 

--- a/src/so-5332-1864/ads13.c
+++ b/src/so-5332-1864/ads13.c
@@ -6,7 +6,6 @@
 */
 
 #include <stdbool.h>
-#include <stdio.h>      /* Debug */
 
 static bool is_all_same_digit(int num)
 {
@@ -36,7 +35,7 @@ static int cmp_numbers(const void *v1, const void *v2)
 #include <stdlib.h>
 #include <string.h>
 
-/* Aka bubble sort! */
+/* Crude algorithm - vaguely resembling bubble sort */
 static void stable_partition(void *data, size_t number, size_t size,
                              int (*cmp)(const void *v1, const void *v2))
 {
@@ -48,8 +47,6 @@ static void stable_partition(void *data, size_t number, size_t size,
             void *vp1 = (char *)data + (j - 1) * size;
             void *vp2 = (char *)data + (j - 0) * size;
             int rc = (*cmp)(vp1, vp2);
-            printf("a[%zu] = %2d; a[%zu] = %2d; cmp = %+d\n",
-                   (j-1), ((int *)data)[(j-1)], j, ((int *)data)[j], rc);
             if (rc > 0)
             {
                 /* Swap 'em */
@@ -93,7 +90,7 @@ static inline int max(int x, int y) { return (x > y) ? x : y; }
 int main(void)
 {
     int ex1[] = { 1, 43, 23, 55 };
-    int ex2[] = { 12, 33, 1, 19, 44, 11, 27, 76, 13 };
+    int ex2[] = { 12, 33, 1, 19, 44, 11, 76, 27, 13 };
     enum { NUM_EX1 = sizeof(ex1) / sizeof(ex1[0]) };
     enum { NUM_EX2 = sizeof(ex2) / sizeof(ex2[0]) };
     int ex3[max(DIM(ex1), DIM(ex2))];

--- a/src/so-5332-1864/ads29.c
+++ b/src/so-5332-1864/ads29.c
@@ -1,7 +1,8 @@
 /* SO 5332-1864 */
 /*
-** Sort array so that the numbers with the same digits are in front of
-** those that ve different digits - in a stable sort
+** Sort array so that the numbers with the all the same digits are in
+** front of those that have different digits, preserving original order
+** of elements within each partition (a stable partition).
 */
 
 #include <stdbool.h>
@@ -72,7 +73,7 @@ static inline int max(int x, int y) { return (x > y) ? x : y; }
 int main(void)
 {
     int ex1[] = { 1, 43, 23, 55 };
-    int ex2[] = { 12, 33, 1, 19, 44, 11, 27, 76, 13 };
+    int ex2[] = { 12, 33, 1, 19, 44, 11, 76, 27, 13 };
     enum { NUM_EX1 = sizeof(ex1) / sizeof(ex1[0]) };
     enum { NUM_EX2 = sizeof(ex2) / sizeof(ex2[0]) };
     int ex3[max(DIM(ex1), DIM(ex2))];

--- a/src/so-5332-1864/ads41.c
+++ b/src/so-5332-1864/ads41.c
@@ -6,6 +6,7 @@
 */
 
 #include <stdbool.h>
+#include <stdio.h>      /* Debug */
 
 static bool is_all_same_digit(int num)
 {
@@ -35,28 +36,64 @@ static int cmp_numbers(const void *v1, const void *v2)
 #include <stdlib.h>
 #include <string.h>
 
-/* Crude algorithm - vaguely resembling bubble sort */
-static void stable_partition(void *data, size_t number, size_t size,
-                             int (*cmp)(const void *v1, const void *v2))
+#define GEN_IDX(arr, idx, size) ((char *)(arr) + (idx) * (size))
+static void insertion_sort_gen(void *data, size_t number, size_t size,
+                           int (*cmp)(const void *v1, const void *v2))
 {
-    for (size_t i = 0; i < number; i++)
+    for (size_t i = 1; i < number; i++)
     {
-        void *vp1 = (char *)data + i * size;
-        for (size_t j = i + 1; j < number; j++)
+        char tmp[size];
+        memmove(tmp, GEN_IDX(data, i, size), size);
+        size_t j;
+        for (j = i; j > 0; j--)
         {
-            void *vp2 = (char *)data + j * size;
-            int rc = (*cmp)(vp1, vp2);
-            if (rc > 0)
-            {
-                /* Swap 'em */
-                char tmp[size];
-                memmove(tmp, vp1, size);
-                memmove(vp1, vp2, size);
-                memmove(vp2, tmp, size);
-            }
+            if ((*cmp)(GEN_IDX(data, j - 1, size), tmp) <= 0)
+                break;
+            memmove(GEN_IDX(data, j, size), GEN_IDX(data, j - 1, size), size);
         }
+        memmove(GEN_IDX(data, j, size), tmp, size);
     }
 }
+
+#if 0
+static void insertion_sort_gen(void *data, size_t number, size_t size,
+                           int (*cmp)(const void *v1, const void *v2))
+{
+    for (size_t i = 1; i < number; i++)
+    {
+        void *vp1 = (char *)data + i * size;
+        char tmp[size];
+        memmove(tmp, vp1, size);
+        size_t j;
+        for (j = i; j > 0; j--)
+        {
+            void *vp2 = (char *)data + (j - 1) * size;
+            int rc = (*cmp)(vp2, tmp);
+            if (rc <= 0)
+                break;
+            void *vp3 = (char *)data + j * size;
+            memmove(vp3, vp2, size);
+        }
+        char *vp4 = (char *)data + j * size;
+        memmove(vp4, tmp, size);
+    }
+}
+#endif
+
+#if 0
+static void insertion_sort_int(int *data, size_t number
+                               int (*cmp)(const void *v1, const void *v2))
+{
+    for (size_t i = 1; i < number; i++)
+    {
+        int t = data[i];
+        size_t j;
+        for (j = i; j > 0 && cmp(&data[j-1], &t) > 0; j--)
+            data[j] = data[j - 1];
+        data[j] = t;
+    }
+}
+#endif
 
 #include <stdio.h>
 
@@ -107,13 +144,15 @@ int main(void)
     memmove(ex3, ex1, sizeof(ex1));
     num3 = NUM_EX1;
     print_array_int("Example 1 stable partition - before", num3, ex3);
-    stable_partition(ex3, num3, sizeof(ex3[0]), cmp_numbers);
+    //insertion_sort_int(ex3, num3);
+    insertion_sort_gen(ex3, num3, sizeof(ex3[0]), cmp_numbers);
     print_array_int("Example 1 stable partition - after", num3, ex3);
 
     memmove(ex3, ex2, sizeof(ex2));
     num3 = NUM_EX2;
     print_array_int("Example 2 stable partition - before", num3, ex3);
-    stable_partition(ex3, num3, sizeof(ex3[0]), cmp_numbers);
+    //insertion_sort_int(ex3, num3);
+    insertion_sort_gen(ex3, num3, sizeof(ex3[0]), cmp_numbers);
     print_array_int("Example 2 stable partition - after", num3, ex3);
 
     return 0;

--- a/src/so-5332-1864/makefile
+++ b/src/so-5332-1864/makefile
@@ -4,9 +4,10 @@ include ../../etc/soq-head.mk
 
 PROG1 = ads13
 PROG2 = ads29
-PROG3 = ads47
+PROG3 = ads41
+PROG4 = ads47
 
-PROGRAMS = ${PROG1} ${PROG2} ${PROG3}
+PROGRAMS = ${PROG1} ${PROG2} ${PROG3} ${PROG4}
 
 all: ${PROGRAMS}
 


### PR DESCRIPTION
Tidy up `ads47.c`, but the bug is still in place; `ad13.c` has the fix and
is OK; `ads29.c` using merge sort is OK; `ads41.c` using insertion sort
is OK.