### PR TITLE
Add the code from SO 5405-4423 as so-5405-4423-v1.c

### DIFF
--- a/src/so-5405-4423/.gitignore
+++ b/src/so-5405-4423/.gitignore
@@ -1,0 +1,7 @@
+so-5405-4423-v?
+strncat19
+strncat29
+strncat37
+strncat97
+strncat??
+test.txt

--- a/src/so-5405-4423/so-5405-4423-v1.c
+++ b/src/so-5405-4423/so-5405-4423-v1.c
@@ -1,0 +1,102 @@
+#include <stdio.h>
+#include <string.h>
+
+char line[1001]; // The line supports up to a 1000 characters
+char lines[11][1001]; // An array of lines (up to 10 lines where each line is a 1000 characters max)
+char info[100]; // Holds extra info provided by user
+
+char * extra_info(
+        char string_1[],
+        char string_2[],
+        char string_3[],
+        char string_4[],
+        char string_5[]
+    );
+
+int main(void){
+
+    int 
+    i, // Line number
+    j; // Length of the line
+    char result[100], text[100];
+    FILE *file;
+
+    strcpy(text, "String No."); // The default text
+
+    file = fopen("test.txt", "w+"); // Open the file for reading and writing
+
+    for(i = 0; i < 10; i++){ // Loop to create a line.
+
+        if(i != 9){ // If the line is NOT at the 10th string
+
+            sprintf(result, "%s%d, ", text, i); // Format the text and store it in result
+
+        }
+        else{
+
+            sprintf(result, "%s%d ", text, i); // Format the text and store it in result            
+
+        }
+
+        extra_info(
+            "st",
+            "nd",
+            "rd",
+            "th",
+            "th"
+        );
+
+        strncat(line, info, 100); // Append the extra info at the end of each line        
+
+        printf("%s", result); // Display the result variable to the screen
+
+        strncat(line, result, 15); // Concatenate all strings in one line
+
+    }
+
+    strncat(line, "\n\n", 2); // Add a new-line character at the end of each line
+
+    for(j = 0; j < 10; j++){ // Now loop to change the line
+
+        strcpy(lines[i], line); // Copy the line of text into each line of the array
+
+        fputs(lines[i], file); // Put each line into the file        
+
+    }
+
+    fclose(file);  
+
+    return 0;
+}
+
+char * extra_info( // Append user defined and predefined info at the end of a line
+        char string_1[],
+        char string_2[],
+        char string_3[],
+        char string_4[],
+        char string_5[]
+    ){
+        char text[100]; // A variable to hold the text
+
+        /* Append a default text into each strings 
+        and concatenate them into one line */
+
+        sprintf(text, " 1%s", string_1);
+        strncat(line, text, 100);
+
+        sprintf(text, ", 2%s", string_2);
+        strncat(line, text, 100);
+
+        sprintf(text, ", 3%s", string_3);
+        strncat(line, text, 100);
+
+        sprintf(text, ", 4%s", string_4);
+        strncat(line, text, 100);
+
+        sprintf(text, ", 5%s.", string_5);
+        strncat(line, text, 100);
+
+        strcpy(info, line); // Copies the line into the info global variable
+
+        return line;
+}

--- a/src/so-5405-4423/so-5405-4423-v2.c
+++ b/src/so-5405-4423/so-5405-4423-v2.c
@@ -1,0 +1,89 @@
+#include <stdio.h>
+#include <string.h>
+
+char line[1001];
+char lines[11][1001];
+char info[100];
+
+char *extra_info(char string_1[], char string_2[], char string_3[],
+                 char string_4[], char string_5[]);
+
+int main(void)
+{
+    char result[100], text[20];
+    const char filename[] = "test.txt";
+    FILE *file;
+
+    strcpy(text, "String No.");
+
+    file = fopen(filename, "w+");
+    if (file == NULL)
+    {
+        fprintf(stderr, "Failed to open file '%s' for writing/update\n", filename);
+        return 1;
+    }
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (i != 9)
+            sprintf(result, "%s%d, ", text, i);
+        else
+            sprintf(result, "%s%d ", text, i);
+
+        fprintf(stderr, "Iteration %d:\n", i);
+        fprintf(stderr, "1 result (%4zu): [%s]\n", strlen(result), result);
+        fprintf(stderr, "1 line   (%4zu): [%s]\n", strlen(line), line);
+        extra_info("st", "nd", "rd", "th", "th");
+        fprintf(stderr, "2 line   (%4zu): [%s]\n", strlen(line), line);
+        fprintf(stderr, "1 info   (%4zu): [%s]\n", strlen(info), info);
+        strncat(line, info, 100);
+        fprintf(stderr, "3 line   (%4zu): [%s]\n", strlen(line), line);
+        printf("%s", result);
+        strncat(line, result, 15);
+        fprintf(stderr, "3 line   (%4zu): [%s]\n", strlen(line), line);
+    }
+
+    fprintf(stderr, "4 line   (%4zu): [%s]\n", strlen(line), line);
+    strncat(line, "\n\n", 2);
+
+    for (int j = 0; j < 10; j++)
+    {
+        strcpy(lines[j], line);
+        fputs(lines[j], file);
+    }
+
+    fclose(file);
+
+    return 0;
+}
+
+char *extra_info(char string_1[], char string_2[], char string_3[],
+                 char string_4[], char string_5[])
+{
+    char text[100];
+
+    sprintf(text, " 1%s", string_1);
+    fprintf(stderr, "EI 1: add (%zu) [%s] to (%zu) [%s]\n", strlen(string_1), string_1, strlen(line), line);
+    strncat(line, text, 100);
+
+    sprintf(text, ", 2%s", string_2);
+    fprintf(stderr, "EI 2: add (%zu) [%s] to (%zu) [%s]\n", strlen(string_2), string_2, strlen(line), line);
+    strncat(line, text, 100);
+
+    sprintf(text, ", 3%s", string_3);
+    fprintf(stderr, "EI 3: add (%zu) [%s] to (%zu) [%s]\n", strlen(string_3), string_3, strlen(line), line);
+    strncat(line, text, 100);
+
+    sprintf(text, ", 4%s", string_4);
+    fprintf(stderr, "EI 4: add (%zu) [%s] to (%zu) [%s]\n", strlen(string_4), string_4, strlen(line), line);
+    strncat(line, text, 100);
+
+    sprintf(text, ", 5%s.", string_5);
+    fprintf(stderr, "EI 5: add (%zu) [%s] to (%zu) [%s]\n", strlen(string_5), string_5, strlen(line), line);
+    strncat(line, text, 100);
+
+    fprintf(stderr, "EI 6: copy (%zu) [%s] to info\n", strlen(line), line);
+    strcpy(info, line);
+
+    return line;
+}


### PR DESCRIPTION
Also add variant code so-5405-4423-v2.c which has a lot of diagnostic
printing added and shows, under lldb on a Mac, that the crash occurs in
`__builtin__strcpy_chk()` (according to the macros) or `__strcpy_chk()`
(accoding to the stack backtrace in `lldb`) in the `strcpy()` at the end
of the `extra_info()` function.