### PR TITLE
SO 1363-6252 — Use official stderr.[ch] now

### DIFF
--- a/src/so-1363-6252/.gitignore
+++ b/src/so-1363-6252/.gitignore
@@ -1,1 +1,2 @@
 pipes-13636252
+pipes-v2


### PR DESCRIPTION
Remove the slightly ad hoc variation on stderr.[ch] and use the version from src/libsoq.