### PR TITLE
Add so-dotarrow script

### DIFF
--- a/src/scripts/.gitignore
+++ b/src/scripts/.gitignore
@@ -14,6 +14,7 @@ rfn-sql
 so
 so-books
 so-c-reserved
+so-dotarrow
 so-esql
 so-getchar
 so-late

--- a/src/scripts/makefile
+++ b/src/scripts/makefile
@@ -33,6 +33,7 @@ PROG19 = soqvg
 PROG20 = so-quotes
 PROG21 = so-reformat-c
 PROG22 = so-esql
+PROG23 = so-dotarrow
 
 PROG08_LINK1 = ${PROG08}-c
 PROG08_LINK2 = ${PROG08}-h
@@ -72,6 +73,7 @@ PROGRAMS = \
 	${PROG20} \
 	${PROG21} \
 	${PROG22} \
+	${PROG23} \
 
 all: ${PROGRAMS} ${PROG08_LINKS}
 

--- a/src/scripts/so-dotarrow.sh
+++ b/src/scripts/so-dotarrow.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Generate standardized message about dot and arrow operators for SO
+
+usage()
+{
+    echo "Usage: $(basename "$0" .sh) [-a|-d] variable member [...]" >&2
+    exit 1
+}
+
+separator="->"
+while getopts "ad" opt
+do
+    case "$opt" in
+    (a) separator="->";;
+    (d) separator=".";;
+    (*) usage;;
+    esac
+done
+
+shift $(($OPTIND - 1))
+
+if [ $# = 1 ]
+then usage
+fi
+
+if [ $# -lt 2 ]
+then set -- ptr member
+fi
+
+str1=$(echo "$@" | sed 's/[[:space:]]\{1,\}/ '"$separator"' /g')
+str2=$(echo "$@" | sed 's/[[:space:]]\{1,\}/'"$separator"'/g')
+
+# Beware back-ticks in unquoted here documents!
+cat << EOF
+Style guide: the dot \`.\` and arrow \`->\` operators bind very tightly and should not be used with spaces around them.
+Writing \`$str1\` is not idiomatic C; use \`$str2\`.
+EOF


### PR DESCRIPTION
Provides a generic style guideline message for people using spaces
around the C dot `.` and arrow `->` operators.

Configurable between using dot (-d) or arrow (-a, default) between members.
Default list is "ptr member" but longer lists or alternative names are
command line arguments (but you must cite at least two names).

There's no provision for `variable->ptrmember.member->data` with a mixed
sequence of dot and arrow operators.
That gets tricky.
Maybe `-r 'variable->ptrmember.member->data'` would work, with the
script spacing out the operators and compressing the spaces.