### PR TITLE
Add code for SO 0017-9565 in src/so-1843-7779.

### DIFF
--- a/src/so-1843-7779/.gitignore
+++ b/src/so-1843-7779/.gitignore
@@ -1,4 +1,5 @@
 sigalrm
 sigchld
+sigexit73
 signals
 sigsync

--- a/src/so-1843-7779/README.md
+++ b/src/so-1843-7779/README.md
@@ -1,4 +1,37 @@
 ### Stack Overflow Question 1843-7779
 
 [SO 1843-7779](https://stackoverflow.com/q/18437779) &mdash;
-Do I need to do anything with a SIGCHLD handler if I am just using wait() to wait for 1 child to finish at a time?
+Do I need to do anything with a SIGCHLD handler if I am just using
+wait() to wait for 1 child to finish at a time?
+
+
+* `sigalrm.c`
+
+  Showing SIGALRM and catching it at work.
+  Uses `microsleep.h` and nominally `microsleep.c` for microsecond
+  sleeping.
+
+* `sigchld.c`
+
+  Showing how handling `SIGCHLD` in different ways affects the way
+  processes get to see children dying.
+
+* `sigexit73.c`
+
+  Showing how `sigaction()` and `SA_SIGINFO` can be used to capture a
+  32-bit exit status on Unix.
+  Built with code from `sigchld.c`.
+
+  Support material for [SO
+  0017-8565](https://stackoverflow.com/q/179565) &mdash; ExitCodes
+  bigger than 255 &mdash; possible?
+
+* `signals.c`
+
+  Showing how `sigaction()` and `SA_SIGINFO` can capture information about
+  which process sent a signal, unlike the regular signal handler.
+
+* `sigsync.c`
+
+  Showing one way in which processes can use `SIGUSR1` to coordinate
+  activity between themselves.

--- a/src/so-1843-7779/makefile
+++ b/src/so-1843-7779/makefile
@@ -6,8 +6,9 @@ PROG1 = sigalrm
 PROG2 = sigchld
 PROG3 = signals
 PROG4 = sigsync
+PROG5 = sigexit73
 
-PROGRAMS = ${PROG1} ${PROG2} ${PROG3} ${PROG4}
+PROGRAMS = ${PROG1} ${PROG2} ${PROG3} ${PROG4} ${PROG5}
 
 all: ${PROGRAMS}
 

--- a/src/so-1843-7779/sigexit73.c
+++ b/src/so-1843-7779/sigexit73.c
@@ -1,0 +1,79 @@
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static siginfo_t sig_info = { 0 };
+static volatile sig_atomic_t sig_num = 0;
+static void *sig_ctxt = 0;
+
+static void catcher(int signum, siginfo_t *info, void *vp)
+{
+    sig_num = signum;
+    sig_info = *info;
+    sig_ctxt = vp;
+}
+
+static void set_handler(int signum)
+{
+    struct sigaction sa;
+    sa.sa_flags = SA_SIGINFO;
+    sa.sa_sigaction = catcher;
+    sigemptyset(&sa.sa_mask);
+
+    if (sigaction(signum, &sa, 0) != 0)
+    {
+        int errnum = errno;
+        fprintf(stderr, "Failed to set signal handler (%d: %s)\n", errnum, strerror(errnum));
+        exit(1);
+    }
+}
+
+static void prt_interrupt(FILE *fp)
+{
+    if (sig_num != 0)
+    {
+        fprintf(fp, "Signal %d from PID %d (status 0x%.8X; UID %d)\n",
+                sig_info.si_signo, (int)sig_info.si_pid, sig_info.si_status,
+                (int)sig_info.si_uid);
+        sig_num = 0;
+    }
+}
+
+static void five_kids(void)
+{
+    const int base = 0xCC00FF40;
+    for (int i = 0; i < 5; i++)
+    {
+        pid_t pid = fork();
+        if (pid < 0)
+            break;
+        else if (pid == 0)
+        {
+            printf("PID %d - exiting with status %d (0x%.8X)\n",
+                   (int)getpid(), base + i, base + i);
+            exit(base + i);
+        }
+        else
+        {
+            int status = 0;
+            pid_t corpse = wait(&status);
+            if (corpse != -1)
+                printf("Child: %d; Corpse: %d; Status = 0x%.4X - waited\n", pid, corpse, (status & 0xFFFF));
+            struct timespec nap = { .tv_sec = 0, .tv_nsec = 1000000 }; // 1 millisecond
+            nanosleep(&nap, 0);
+            prt_interrupt(stdout);
+            fflush(0);
+        }
+    }
+}
+
+int main(void)
+{
+    set_handler(SIGCHLD);
+    five_kids();
+}


### PR DESCRIPTION
The code shown in the question is in `sigexit73.c`.  It demonstrates that
with some hard work, finnagling, and a modicum of luck and/or care, you can
get a 32-bit exit status back from a child process.